### PR TITLE
feat: add window number component

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ sections = {lualine_a = {'mode'}}
 * `mode` (vim mode)
 * `progress` (%progress in file)
 * `tabs` (shows currently available tabs)
+* `window` (window number)
 
 </details>
 

--- a/lua/lualine/components/window.lua
+++ b/lua/lualine/components/window.lua
@@ -1,0 +1,7 @@
+-- Copyright (c) 2020-2021 Daniel Hjelm (github.com/hjelm)
+-- MIT license, see LICENSE for more details.
+local function window()
+  return vim.api.nvim_win_get_number(0)
+end
+
+return window


### PR DESCRIPTION
This component is particularly useful for people with key bindings similar to the following:
```
nnoremap <silent> <leader>w1 :1wincmd w <cr>
nnoremap <silent> <leader>w2 :2wincmd w <cr>
nnoremap <silent> <leader>w3 :3wincmd w <cr>
nnoremap <silent> <leader>w4 :4wincmd w <cr>
nnoremap <silent> <leader>w5 :5wincmd w <cr>
nnoremap <silent> <leader>w6 :6wincmd w <cr>
nnoremap <silent> <leader>w7 :7wincmd w <cr>
nnoremap <silent> <leader>w8 :8wincmd w <cr>
nnoremap <silent> <leader>w9 :9wincmd w <cr>
nnoremap <silent> <leader>w0 :10wincmd w <cr>
```
If you have many windows open, it's really simple to switch between them with this window number component.