### PR TITLE
feature(buffers): option to show buffer index

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,10 @@ sections = {
     {
       'buffers',
       show_filename_only = true, -- shows shortened relative path when false
-      show_modified_status = true -- shows indicator then bufder is modified
+      show_modified_status = true -- shows indicator then buffer is modified
+      mode = 0, -- 0 shows buffer name
+                -- 1 buffer index (bufnr)
+                -- 2 shows buffer name + buffer index (bufnr)
       max_length = vim.o.columns * 2 / 3, -- maximum width of buffers component
                                           -- can also be a function that returns value of max_length dynamicaly
       filetype_names = {

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -410,7 +410,10 @@ will be.
         {
           'buffers',
           show_filename_only = true, -- shows shortened relative path when false
-          show_modified_status = true -- shows indicator then bufder is modified
+          show_modified_status = true -- shows indicator then buffer is modified
+          mode = 0, -- 0 shows buffer name
+                    -- 1 buffer index (bufnr)
+                    -- 2 shows buffer name + buffer index (bufnr)
           max_length = vim.o.columns * 2 / 3, -- maximum width of buffers component
                                               -- can also be a function that returns value of max_length dynamicaly
           filetype_names = {

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -48,10 +48,17 @@ end
 ---@return string
 function Buffer:render()
   local name
+
   if self.ellipse then -- show elipsis
     name = '...'
   else
-    name = string.format(' %s%s%s ', self.icon, self:name(), self.modified_icon)
+    if self.options.mode == 0 then
+      name = string.format(' %s%s%s ', self.icon, self:name(), self.modified_icon)
+    elseif self.options.mode == 1 then
+      name = string.format(' %s %s%s ', self.bufnr, self.icon, self.modified_icon)
+    else
+      name = string.format(' %s %s%s%s ', self.bufnr, self.icon, self:name(), self.modified_icon)
+    end
   end
   self.len = vim.fn.strchars(name)
 

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -8,6 +8,7 @@ local highlight = require 'lualine.highlight'
 local default_options = {
   show_filename_only = true,
   show_modified_status = true,
+  mode = 0,
   max_length = 0,
   filetype_names = {
     TelescopePrompt = 'Telescope',


### PR DESCRIPTION
Hey!

Here's a little feature to the `buffers` component which allows to display buffer index (also known as "number")

It's useful when you have mappings like `4gb` (open buffer 4).

![image](https://user-images.githubusercontent.com/5887089/141471387-9e99ff27-de3e-4c23-9250-299cc5ea904a.png)

Thanks for the plugin, btw!