### PR TITLE
Introduce Base 16 Ocean theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -43,6 +43,14 @@ it'll try it's best to generate one.
 It's a combination of ayu_light, ayu_dark & ayu_mirage. It loads one of these
 them based you your `g:ayucolor` option.
 
+### base16_ocean
+<p>
+<img width='700' src='https://user-images.githubusercontent.com/564113/141649910-1f14e0bc-98b6-4439-9e85-4584106022ad.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/564113/141649934-55508a08-a0cc-4714-bb48-03bf273e4b94.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/564113/141649942-633526a0-ef09-4b43-8d61-48e83dc74c90.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/564113/141649946-4aebbc45-bda1-49c7-a1e8-0449adbf0adf.png'/>
+</p>
+
 ### codedark
 <p>
 <img width='700' src='https://user-images.githubusercontent.com/41551030/108648568-dff4c980-74bb-11eb-9d16-b68ac68f2ab2.png'/>

--- a/lua/lualine/themes/base16_ocean.lua
+++ b/lua/lualine/themes/base16_ocean.lua
@@ -1,0 +1,48 @@
+-- MIT license, see LICENSE for more details.
+-- stylelua: ignore
+local colors = {
+  color00 = "#2b303b",
+  color01 = "#343d46",
+  color02 = "#4f5b66",
+  color03 = "#65737e",
+  color04 = "#a7adba",
+  color05 = "#c0c5ce",
+  color06 = "#dfe1e8",
+  color07 = "#eff1f5",
+  color08 = "#bf616a",
+  color09 = "#d08770",
+  color0A = "#ebcb8b",
+  color0B = "#a3be8c",
+  color0C = "#96b5b4",
+  color0D = "#8fa1b3",
+  color0E = "#b48ead",
+  color0F = "#ab7967",
+}
+
+return {
+  normal = {
+    a = { fg = colors.color01, bg = colors.color0B, gui = 'bold' },
+    b = { fg = colors.color06, bg = colors.color02 },
+    c = { fg = colors.color09, bg = colors.color01 }
+  },
+  insert = {
+    a = { fg = colors.color01, bg = colors.color0D, gui = 'bold'},
+    b = { fg = colors.color06, bg = colors.color02 },
+    c = { fg = colors.color09, bg = colors.color01 }
+  },
+  replace = {
+    a = { fg = colors.color01, bg = colors.color08, gui = 'bold' },
+    b = { fg = colors.color06, bg = colors.color02 },
+    c = { fg = colors.color09, bg = colors.color01 }
+  },
+  visual = {
+    a = { fg = colors.color01, bg = colors.color0E, gui = 'bold' },
+    b = { fg = colors.color06, bg = colors.color02 },
+    c = { fg = colors.color09, bg = colors.color01 }
+  },
+  inactive = {
+    a = { fg = colors.color05, bg = colors.color01, gui = 'bold' },
+    b = { fg = colors.color05, bg = colors.color01 },
+    c = { fg = colors.color05, bg = colors.color01 }
+  },
+}


### PR DESCRIPTION
This PR adds the base16-ocean theme from http://chriskempson.com/projects/base16 which I borrowed the [vim-airline-themes implementation](https://github.com/vim-airline/vim-airline-themes/blob/97cf3e6e638f936187d5f6e9b5eb1bdf0a4df256/autoload/airline/themes/base16_ocean.vim) of.

<img width="1728" alt="Screen Shot 2021-11-13 at 10 34 20 AM" src="https://user-images.githubusercontent.com/564113/141650146-dec108f0-5b1b-462c-9c84-56656a91adbc.png">
<img width="1728" alt="Screen Shot 2021-11-13 at 10 34 32 AM" src="https://user-images.githubusercontent.com/564113/141650147-d5ce702e-53d7-4735-9a6f-1458191d33e2.png">
<img width="1728" alt="Screen Shot 2021-11-13 at 10 34 50 AM" src="https://user-images.githubusercontent.com/564113/141650150-a061c4ea-6d24-442f-8317-562147005892.png">
<img width="1728" alt="Screen Shot 2021-11-13 at 10 34 42 AM" src="https://user-images.githubusercontent.com/564113/141650149-b4d9c1c1-6831-4784-b7a5-bdafc1e2f531.png">


Thanks for a great plugin!