### PR TITLE
fix(diagnostics): adapt nvim source to breaking change

### DIFF
--- a/lua/lualine/components/diagnostics/sources.lua
+++ b/lua/lualine/components/diagnostics/sources.lua
@@ -12,7 +12,7 @@ M.sources = {
     return error_count, warning_count, info_count, hint_count
   end,
   nvim = function()
-    local diagnostics = vim.diagnostic.get(0)
+    local diagnostics = vim.diagnostic.get(vim.fn.bufnr())
     local count = { 0, 0, 0, 0 }
     for _, diagnostic in ipairs(diagnostics) do
       count[diagnostic.severity] = count[diagnostic.severity] + 1

--- a/lua/lualine/components/diagnostics/sources.lua
+++ b/lua/lualine/components/diagnostics/sources.lua
@@ -5,10 +5,11 @@ local M = {}
 ---        info_count:number, hint_count:number
 M.sources = {
   nvim_lsp = function()
-    local error_count = vim.lsp.diagnostic.get_count(0, 'Error')
-    local warning_count = vim.lsp.diagnostic.get_count(0, 'Warning')
-    local info_count = vim.lsp.diagnostic.get_count(0, 'Information')
-    local hint_count = vim.lsp.diagnostic.get_count(0, 'Hint')
+    local bufnr = vim.fn.bufnr()
+    local error_count = vim.lsp.diagnostic.get_count(bufnr, 'Error')
+    local warning_count = vim.lsp.diagnostic.get_count(bufnr, 'Warning')
+    local info_count = vim.lsp.diagnostic.get_count(bufnr, 'Information')
+    local hint_count = vim.lsp.diagnostic.get_count(bufnr, 'Hint')
     return error_count, warning_count, info_count, hint_count
   end,
   nvim = function()


### PR DESCRIPTION
Explicitly pass `bufnr` for both `nvim` and `nvim-lsp` diagnostic sources, as required by upstream breaking change: https://github.com/neovim/neovim/pull/16405

(Separate commits in case you don't want to change the "legacy" source.)