### PR TITLE
Fix: Right highlight groups require explicit normal mode set

### DIFF
--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -249,11 +249,11 @@ end
 ---@param is_focused boolean
 ---@return string formatted highlight group name
 function M.format_highlight(highlight_group, is_focused)
-  if highlight_group > 'lualine_c' and not M.highlight_exists(highlight_group .. '_normal') then
+  local highlight_name = M.append_mode(highlight_group, is_focused)
+  if highlight_group > 'lualine_c' and not M.highlight_exists(highlight_name) then
     highlight_group = 'lualine_' .. section_highlight_map[highlight_group:match 'lualine_(.)']
+    highlight_name = M.append_mode(highlight_group, is_focused)
   end
-  local highlight_name
-  highlight_name = M.append_mode(highlight_group, is_focused)
   if M.highlight_exists(highlight_name) then
     return '%#' .. highlight_name .. '#'
   end


### PR DESCRIPTION
Found this pretty confusing when trying to set up a theme.

I have a custom theme something like below in which I wanted to customise the `y` section on for `inactive`. This unfortunately didn't work and left me scratching my head for some time.

I think this PR addresses the bug and has fixed the problem for me.

```lua
local nord_theme = {
    normal = {
        a = {bg = colors.nord8_gui, fg = colors.nord0_gui},
        b = {bg = colors.nord1_gui, fg = colors.nord4_gui},
        c = {bg = colors.nord3_gui, fg = colors.nord4_gui}
    },
    insert = {
        a = {bg = colors.nord4_gui, fg = colors.nord0_gui},
        b = {bg = colors.nord1_gui, fg = colors.nord4_gui},
        c = {bg = colors.nord3_gui, fg = colors.nord4_gui}
    },
    visual = {
        a = {bg = colors.nord7_gui, fg = colors.nord0_gui},
        b = {bg = colors.nord1_gui, fg = colors.nord4_gui},
        c = {bg = colors.nord3_gui, fg = colors.nord4_gui}
    },
    replace = {
        a = {bg = colors.nord13_gui, fg = colors.nord0_gui},
        b = {bg = colors.nord1_gui, fg = colors.nord4_gui},
        c = {bg = colors.nord3_gui, fg = colors.nord4_gui}
    },
    command = {
        a = {bg = colors.nord8_gui, fg = colors.nord0_gui},
        b = {bg = colors.nord1_gui, fg = colors.nord4_gui},
        c = {bg = colors.nord3_gui, fg = colors.nord4_gui}
    },
    inactive = {
        a = {bg = colors.nord4_gui, fg = colors.nord1_gui},
        b = {bg = colors.nord1_gui, fg = colors.nord4_gui},
        c = {bg = colors.nord3_gui, fg = colors.nord4_gui},
        y = {bg = colors.nord3_gui, fg = colors.nord4_gui}
    }
}
```