### PR TITLE
Fix: remove commands in default group when reset lualine

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -278,7 +278,7 @@ local function reset_lualine()
     -- When notices module is not loaded there are no notices to clear.
     modules.utils_notices.clear_notices()
   end
-  vim.cmd [[augroup lualine | autocmd! | augroup END]]
+  vim.cmd [[augroup lualine | exe "autocmd!" | augroup END]]
   setup_theme()
   -- load components & extensions
   modules.loader.load_all(config)


### PR DESCRIPTION
According to nvim document,

```txt
Note: The ":autocmd" command can only be followed by another command when the
'|' appears where the pattern is expected.  This works:
	:augroup mine | au! BufRead | augroup END
But this sees "augroup" as part of the defined command:
	:augroup mine | au! BufRead * | augroup END
	:augroup mine | au BufRead * set tw=70 | augroup END
Instead you can put the group name into the command:
	:au! mine BufRead *
	:au mine BufRead * set tw=70
Or use `:execute`:
	:augroup mine | exe "au! BufRead *" | augroup END
	:augroup mine | exe "au BufRead * set tw=70" | augroup END
```

After call ```vim.cmd [[augroup lualine | autocmd! | augroup END]]```, we select ```lualine``` group, but don't go back to default group.

More detail, see: https://neovim.io/doc/user/autocmd.html#autocmd-define
