### PR TITLE
feat(filename): add unnamed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,10 +503,15 @@ sections = {
   lualine_a = {
     {
       'filename',
-      file_status = true,  -- displays file status (readonly status, modified status)
-      path = 0,            -- 0 = just filename, 1 = relative path, 2 = absolute path
-      shorting_target = 40 -- Shortens path to leave 40 space in the window
-                           -- for other components. Terrible name any suggestions?
+      file_status = true,   -- displays file status (readonly status, modified status)
+      path = 0,             -- 0 = just filename, 1 = relative path, 2 = absolute path
+      shorting_target = 40, -- Shortens path to leave 40 space in the window
+                            -- for other components. Terrible name any suggestions?
+      symbols = {
+        modified = '[+]',      -- when the file was modified
+        readonly = '[-]',      -- if the file is not modifiable or readonly
+        unnamed = '[No Name]', -- default display name for unnamed buffers
+      }
     }
   }
 }

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -530,10 +530,15 @@ Component specific options             These are options that are available on
       lualine_a = {
         {
           'filename',
-          file_status = true,  -- displays file status (readonly status, modified status)
-          path = 0,            -- 0 = just filename, 1 = relative path, 2 = absolute path
-          shorting_target = 40 -- Shortens path to leave 40 space in the window
-                               -- for other components. Terrible name any suggestions?
+          file_status = true,   -- displays file status (readonly status, modified status)
+          path = 0,             -- 0 = just filename, 1 = relative path, 2 = absolute path
+          shorting_target = 40, -- Shortens path to leave 40 space in the window
+                                -- for other components. Terrible name any suggestions?
+          symbols = {
+            modified = '[+]',      -- when the file was modified
+            readonly = '[-]',      -- if the file is not modifiable or readonly
+            unnamed = '[No Name]', -- default display name for unnamed buffers
+          }
         }
       }
     }

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -3,7 +3,7 @@
 local M = require('lualine.component'):extend()
 
 local default_options = {
-  symbols = { modified = '[+]', readonly = '[-]' },
+  symbols = { modified = '[+]', readonly = '[-]', unnamed = '[No Name]' },
   file_status = true,
   path = 0,
   shorting_target = 40,
@@ -45,7 +45,7 @@ M.update_status = function(self)
   end
 
   if data == '' then
-    data = '[No Name]'
+    data = self.options.symbols.unnamed
   end
 
   if self.options.shorting_target ~= 0 then


### PR DESCRIPTION
This makes the `[No Name]` text, which is shown when a buffer is unnamed, customizable.