### PR TITLE
fix: don't hide readonly symbol when modified

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -63,7 +63,8 @@ M.update_status = function(self)
   if self.options.file_status then
     if vim.bo.modified then
       data = data .. self.options.symbols.modified
-    elseif vim.bo.modifiable == false or vim.bo.readonly == true then
+    end
+    if vim.bo.modifiable == false or vim.bo.readonly == true then
       data = data .. self.options.symbols.readonly
     end
   end


### PR DESCRIPTION
Currently if you're editing a readonly file and made any changes, only the modified symbol is shown. With this PR it will show both.