### PR TITLE
docs: keep the same style across documentation & fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Please create a pr if you managed to port a popular theme before me, [here is ho
 ```lua
 local custom_gruvbox = require'lualine.themes.gruvbox'
 -- Change the background of lualine_c section for normal mode
-custom_gruvbox.normal.c.bg = '#112233' -- rgb colors are supported
+custom_gruvbox.normal.c.bg = '#112233' -- RGB colors are supported
 require'lualine'.setup{
   options = { theme  = custom_gruvbox },
   ...
@@ -331,10 +331,10 @@ options = {
   theme = 'auto',              -- lualine theme
   component_separators = {left = '', right = ''},
   section_separators = {left = '', right = ''},
-  disabled_filetypes = {},     -- filetypes to disable lualine for
-  always_divide_middle = true, -- when set to true, left_sections (a,b,c)
-                               -- can't take over entire statusline even if
-                               -- neither of 'x', 'y' or 'z' are present.
+  disabled_filetypes = {},     -- Filetypes to disable lualine for.
+  always_divide_middle = true, -- When set to true, left sections i.e. 'a','b' and 'c'
+                               -- can't take over the entire statusline even
+                               -- if neither of 'x', 'y' or 'z' are present.
 }
 ```
 
@@ -348,43 +348,51 @@ sections = {
   lualine_a = {
     {
       'mode',
-      icons_enabled = true, -- enables the display of icons alongside the component.
-      icon = nil,      -- defines the icon to be displayed in front of the component.
-      separator = nil, -- determines what separator to use for the component.
-                       -- when a string is given it's treated as component_separator.
-                       -- when a table is given it's treated as section_separator.
-                       -- these options can be used to set colored separators
-                       -- around a component. The options need to be set like
-                       -- `separator = { left = '', right = ''}`.
-                       -- where left will be placed on left side of component
-                       -- and right will be placed on right side of component.
-                       -- passing an empty string disables that separator.
-      cond = nil, -- condition function, component is loaded when the function returns true
-      -- custom color for the component in format
-      -- here '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
+      icons_enabled = true, -- Enables the display of icons alongside the component.
+      icon = nil,      -- Defines the icon to be displayed in front of the component.
+
+      separator = nil, -- Determines what separator to use for the component.
+                       -- When a string is provided it's treated as component_separator.
+                       -- When a table is provided it's treated as section_separator.
+                       -- These options can be used to set colored separators
+                       -- around a component. 
+                       --
+                       -- The options need to be set like:
+                       --   separator = { left = '', right = ''}
+                       --
+                       -- Where left will be placed on left side of component,
+                       -- and right will be placed on its right.
+                       -- Passing an empty string disables the separator.
+
+      cond = nil, -- Condition function, the component is loaded when the function returns `true`.
+
+      -- Custom color for the component in format
+      -- here, '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
       -- 'highlight_group_name' | {fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style'}
       --
-      -- note: all other color options including themes accept like diff_color same color values.
+      -- Note: all other color options including themes accept like diff_color same color values.
       --
       -- example:
       --   color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
-      --   color = {fg = 204} -- when fg/bg is skiped they default to themes fg/bg
-      --   color = 'WarningMsg'
+      --   color = {fg = 204}   -- when fg/bg is skiped they default to themes fg/bg
+      --   color = 'WarningMsg' -- highlight groups can also be used
       --
-      -- or highlight group
-      -- color = "WarningMsg"
       color = nil, -- default is themes color for that section and mode
-      -- Type option specifies what type a component is.
-      -- When type is omitted lualine will guess it.
-      -- Available types [format: type_name(example)]
-      -- mod(branch/filename), stl(%f/%m), var(g:coc_status/bo:modifiable),
-      -- lua_expr(lua expressions), vim_fun(viml function name)
+
+      -- This option specifies what type a component is.
+      -- When it's omitted lualine will guess it for you.
+      -- 
+      -- Available types are:
+      --   [format: type_name(example)], mod(branch/filename),
+      --   stl(%f/%m), var(g:coc_status/bo:modifiable),
+      --   lua_expr(lua expressions), vim_fun(viml function name)
+      --
       -- lua_expr is short for lua-expression and vim_fun is short fror vim-function
       type = nil,
-      padding = 1, -- adds padding to the left and right of components
-                   -- padding can be specified to left or right separately like
-                   -- padding = { left = left_padding, right = right_padding }
-      fmt = nil,   -- format function, formats the component's output
+      padding = 1, -- Adds padding to the left and right of components.
+                   -- Padding can be specified to left or right independently, e.g.:
+                   --   padding = { left = left_padding, right = right_padding }
+      fmt = nil,   -- Format function, formats the component's output.
     }
   }
 }
@@ -403,24 +411,25 @@ sections = {
   lualine_a = {
     {
       'buffers',
-      show_filename_only = true,   -- shows shortened relative path when false
-      show_modified_status = true, -- shows indicator then buffer is modified
-      mode = 0, -- 0: shows buffer name
-                -- 1: shows buffer index (bufnr)
-                -- 2: shows buffer name + buffer index (bufnr)
-      max_length = vim.o.columns * 2 / 3, -- maximum width of buffers component
-                                          -- can also be a function that returns value of max_length dynamically
+      show_filename_only = true,   -- Shows shortened relative path when set to false
+      show_modified_status = true, -- Shows indicator then buffer is modified
+      mode = 0, -- 0: Shows buffer name
+                -- 1: Shows buffer index (bufnr)
+                -- 2: Shows buffer name + buffer index (bufnr)
+      max_length = vim.o.columns * 2 / 3, -- Maximum width of buffers component,
+                                          -- it can also be a function that returns
+                                          -- the value of `max_length` dynamically.
       filetype_names = {
         TelescopePrompt = 'Telescope',
         dashboard = 'Dashboard',
         packer = 'Packer',
         fzf = 'FZF',
         alpha = 'Alpha'
-      }, -- shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
+      }, -- Shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
       buffers_color = {
         -- Same values like general color option can be used here.
-        active = 'lualine_{section}_normal',     -- color for active buffer
-        inactive = 'lualine_{section}_inactive', -- color for inactive buffer
+        active = 'lualine_{section}_normal',     -- Color for active buffer
+        inactive = 'lualine_{section}_inactive', -- Color for inactive buffer
       },
     }
   }
@@ -434,8 +443,8 @@ sections = {
   lualine_a = {
     {
       'diagnostics',
-      -- table of diagnostic sources, available sources:
-      -- 'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'
+      -- Table of diagnostic sources, available sources are:
+      --   'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'.
       -- or a function that returns a table like:
       --   {error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt}
       sources = {'nvim_diagnostic', 'coc'},
@@ -443,15 +452,15 @@ sections = {
       sections = {'error', 'warn', 'info', 'hint'},
       diagnostics_color = {
         -- Same values like general color option can be used here.
-        error = 'DiagnosticError', -- changes diagnostic's error color
-        warn  = 'DiagnosticWarn',  -- changes diagnostic's warn color
-        info  = 'DiagnosticInfo',  -- changes diagnostic's info color
-        hint  = 'DiagnosticHint',  -- changes diagnostic's hint color
+        error = 'DiagnosticError', -- Changes diagnostics' error color
+        warn  = 'DiagnosticWarn',  -- Changes diagnostics' warn color
+        info  = 'DiagnosticInfo',  -- Changes diagnostics' info color
+        hint  = 'DiagnosticHint',  -- Changes diagnostics' hint color
       },
       symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'},
-      colored = true,           -- displays diagnostics status in color if set to true
-      update_in_insert = false, -- update diagnostics in insert mode
-      always_visible = false,   -- show diagnostics even if count is 0, boolean or function returning boolean
+      colored = true,           -- Displays diagnostics status in color if set to true
+      update_in_insert = false, -- Update diagnostics in insert mode
+      always_visible = false,   -- Show diagnostics even if there are none
     }
   }
 }
@@ -464,17 +473,17 @@ sections = {
   lualine_a = {
     {
       'diff',
-      colored = true, -- displays diff status in color if set to true
-      -- all colors are in format #rrggbb
+      colored = true, -- Displays diff status in color if set to true
+      -- All colors are in #rrggbb format
       diff_color = {
         -- Same values like general color option can be used here.
-        added    = 'DiffAdd',    -- changes diff's added color
-        modified = 'DiffChange', -- changes diff's modified color
-        removed  = 'DiffDelete', -- changes diff's removed color you
+        added    = 'DiffAdd',    -- Changes the diff's added color
+        modified = 'DiffChange', -- Changes the diff's modified color
+        removed  = 'DiffDelete', -- Changes the diff's removed color you
       },
-      symbols = {added = '+', modified = '~', removed = '-'}, -- changes diff symbols
-      source = nil, -- a function that works as a data source for diff.
-                    -- it must return a table like:
+      symbols = {added = '+', modified = '~', removed = '-'}, -- Changes the symbols used by the diff
+      source = nil, -- A function that works as a data source for diff.
+                    -- It must return a table like:
                     --   {added = add_count, modified = modified_count, removed = removed_count }
                     -- or nil on failure. count <= 0 won't be displayed.
     }
@@ -506,18 +515,18 @@ sections = {
   lualine_a = {
     {
       'filename',
-      file_status = true, -- displays file status (readonly status, modified status)
-      path = 0,           -- 0: just filename
-                          -- 1: relative path
-                          -- 2: absolute path
+      file_status = true, -- Displays file status (readonly status, modified status)
+      path = 0,           -- 0: Just the filename
+                          -- 1: Relative path
+                          -- 2: Absolute path
 
 
-      shorting_target = 40, -- shortens path to leave 40 spaces in the window
+      shorting_target = 40, -- Shortens path to leave 40 spaces in the window
                             -- for other components. (terrible name, any suggestions?)
       symbols = {
-        modified = '[+]',      -- text to show when the file is modified
-        readonly = '[-]',      -- text to show when the file is non-modifiable or readonly
-        unnamed = '[No Name]', -- text to show for unnamed buffers
+        modified = '[+]',      -- Text to show when the file is modified
+        readonly = '[-]',      -- Text to show when the file is non-modifiable or readonly
+        unnamed = '[No Name]', -- Text to show for unnamed buffers
       }
     }
   }
@@ -531,8 +540,8 @@ sections = {
   lualine_a = {
     {
       'filetype',
-      colored = true, -- displays filetype icon in color if set to true
-      icon_only = false -- display only an icon for filetype
+      colored = true, -- Displays filetype icon in color if set to true
+      icon_only = false -- Display only an icon for filetype
     }
   }
 }
@@ -545,11 +554,13 @@ sections = {
   lualine_a = {
     {
       'tabs',
-      max_length = vim.o.columns / 3, -- maximum width of tabs component
-                                      -- can also be a function that returns value of max_length dynamically
-      mode = 0, -- 0: shows tab_nr
-                -- 1: shows tab_name
-                -- 2: shows tab_nr + tab_name
+      max_length = vim.o.columns / 3, -- Maximum width of tabs component,
+                                      -- it can also be a function that returns 
+                                      -- the value of `max_length` dynamically.
+      mode = 0, -- 0: Shows tab_nr
+                -- 1: Shows tab_name
+                -- 2: Shows tab_nr + tab_name
+
       tabs_color = {
         -- Same values like general color option can be used here.
         active = 'lualine_{section}_normal',   -- color for active tab

--- a/README.md
+++ b/README.md
@@ -328,13 +328,13 @@ the option value in component.
 
 ```lua
 options = {
-  theme = 'auto',          -- lualine theme
+  theme = 'auto',              -- lualine theme
   component_separators = {left = '', right = ''},
   section_separators = {left = '', right = ''},
-  disabled_filetypes = {},  -- filetypes to disable lualine on
-  always_divide_middle = true, -- When true left_sections (a,b,c) can't
-                               -- take over entiee statusline even
-                               -- when none of section x, y, z is present.
+  disabled_filetypes = {},     -- filetypes to disable lualine for
+  always_divide_middle = true, -- when set to true, left_sections (a,b,c)
+                               -- can't take over entire statusline even if
+                               -- neither of 'x', 'y' or 'z' are present.
 }
 ```
 
@@ -348,26 +348,29 @@ sections = {
   lualine_a = {
     {
       'mode',
-      icons_enabled = true, -- displays icons in alongside component
-      icon = nil,      -- displays icon in front of the component
-      separator = nil, -- Determines what separator to use for the component.
+      icons_enabled = true, -- enables the display of icons alongside the component.
+      icon = nil,      -- defines the icon to be displayed in front of the component.
+      separator = nil, -- determines what separator to use for the component.
                        -- when a string is given it's treated as component_separator.
-                       -- When a table is given it's treated as section_separator.
-                       -- This options can be used to set colored separators
-                       -- arround component. Option need to be set like
+                       -- when a table is given it's treated as section_separator.
+                       -- these options can be used to set colored separators
+                       -- around a component. The options need to be set like
                        -- `separator = { left = '', right = ''}`.
-                       -- Where left will be placed in left side of component
-                       -- and right will be placed in right side of component
-                       -- Passing empty string disables that separator
-      cond = nil, -- condition function, component is loaded when function returns true
+                       -- where left will be placed on left side of component
+                       -- and right will be placed on right side of component.
+                       -- passing an empty string disables that separator.
+      cond = nil, -- condition function, component is loaded when the function returns true
       -- custom color for the component in format
-      -- here '|' refers to or meaning a different acceptable format for that placeholder
+      -- here '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
       -- 'highlight_group_name' | {fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style'}
-      --  Note: all other color options including themes accept  like diff_color same color values
-      -- Example
-      -- color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
-      -- color = {fg = 204} -- when fg/bg is skiped they default to themes fg/bg
-      -- color = 'WarningMsg'
+      --
+      -- note: all other color options including themes accept like diff_color same color values.
+      --
+      -- example:
+      --   color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
+      --   color = {fg = 204} -- when fg/bg is skiped they default to themes fg/bg
+      --   color = 'WarningMsg'
+      --
       -- or highlight group
       -- color = "WarningMsg"
       color = nil, -- default is themes color for that section and mode
@@ -381,7 +384,7 @@ sections = {
       padding = 1, -- adds padding to the left and right of components
                    -- padding can be specified to left or right separately like
                    -- padding = { left = left_padding, right = right_padding }
-      fmt = nil,   -- format function, formats component's output
+      fmt = nil,   -- format function, formats the component's output
     }
   }
 }
@@ -400,13 +403,13 @@ sections = {
   lualine_a = {
     {
       'buffers',
-      show_filename_only = true, -- shows shortened relative path when false
+      show_filename_only = true,   -- shows shortened relative path when false
       show_modified_status = true, -- shows indicator then buffer is modified
-      mode = 0, -- 0 shows buffer name
-                -- 1 buffer index (bufnr)
-                -- 2 shows buffer name + buffer index (bufnr)
+      mode = 0, -- 0: shows buffer name
+                -- 1: shows buffer index (bufnr)
+                -- 2: shows buffer name + buffer index (bufnr)
       max_length = vim.o.columns * 2 / 3, -- maximum width of buffers component
-                                          -- can also be a function that returns value of max_length dynamicaly
+                                          -- can also be a function that returns value of max_length dynamically
       filetype_names = {
         TelescopePrompt = 'Telescope',
         dashboard = 'Dashboard',
@@ -416,7 +419,7 @@ sections = {
       }, -- shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
       buffers_color = {
         -- Same values like general color option can be used here.
-        active = 'lualine_{section}_normal', -- color for active buffer
+        active = 'lualine_{section}_normal',     -- color for active buffer
         inactive = 'lualine_{section}_inactive', -- color for inactive buffer
       },
     }
@@ -433,7 +436,7 @@ sections = {
       'diagnostics',
       -- table of diagnostic sources, available sources:
       -- 'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'
-      -- Or a function that returns a table like
+      -- or a function that returns a table like:
       --   {error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt}
       sources = {'nvim_diagnostic', 'coc'},
       -- displays diagnostics from defined severity
@@ -446,9 +449,9 @@ sections = {
         hint  = 'DiagnosticHint',  -- changes diagnostic's hint color
       },
       symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'},
-      colored = true, -- displays diagnostics status in color if set to true
-      update_in_insert = false, -- Update diagnostics in insert mode
-      always_visible = false, -- Show diagnostics even if count is 0, boolean or function returning boolean
+      colored = true,           -- displays diagnostics status in color if set to true
+      update_in_insert = false, -- update diagnostics in insert mode
+      always_visible = false,   -- show diagnostics even if count is 0, boolean or function returning boolean
     }
   }
 }
@@ -470,10 +473,10 @@ sections = {
         removed  = 'DiffDelete', -- changes diff's removed color you
       },
       symbols = {added = '+', modified = '~', removed = '-'}, -- changes diff symbols
-      source = nil, -- A function that works as a data source for diff.
-                    -- it must return a table like
-                    -- {added = add_count, modified = modified_count, removed = removed_count }
-                    -- Or nil on failure. Count <= 0 won't be displayed.
+      source = nil, -- a function that works as a data source for diff.
+                    -- it must return a table like:
+                    --   {added = add_count, modified = modified_count, removed = removed_count }
+                    -- or nil on failure. count <= 0 won't be displayed.
     }
   }
 }
@@ -488,8 +491,8 @@ sections = {
       'fileformat',
       symbols = {
         unix = '', -- e712
-        dos = '', -- e70f
-        mac = '', -- e711
+        dos = '',  -- e70f
+        mac = '',  -- e711
       }
     }
   }
@@ -503,14 +506,18 @@ sections = {
   lualine_a = {
     {
       'filename',
-      file_status = true,   -- displays file status (readonly status, modified status)
-      path = 0,             -- 0 = just filename, 1 = relative path, 2 = absolute path
-      shorting_target = 40, -- Shortens path to leave 40 space in the window
-                            -- for other components. Terrible name any suggestions?
+      file_status = true, -- displays file status (readonly status, modified status)
+      path = 0,           -- 0: just filename
+                          -- 1: relative path
+                          -- 2: absolute path
+
+
+      shorting_target = 40, -- shortens path to leave 40 spaces in the window
+                            -- for other components. (terrible name, any suggestions?)
       symbols = {
-        modified = '[+]',      -- when the file was modified
-        readonly = '[-]',      -- if the file is not modifiable or readonly
-        unnamed = '[No Name]', -- default display name for unnamed buffers
+        modified = '[+]',      -- text to show when the file is modified
+        readonly = '[-]',      -- text to show when the file is non-modifiable or readonly
+        unnamed = '[No Name]', -- text to show for unnamed buffers
       }
     }
   }
@@ -524,8 +531,8 @@ sections = {
   lualine_a = {
     {
       'filetype',
-      colored = true, -- displays filetype icon in color if set to `true
-      icon_only = false -- Display only icon for filetype
+      colored = true, -- displays filetype icon in color if set to true
+      icon_only = false -- display only an icon for filetype
     }
   }
 }
@@ -539,10 +546,10 @@ sections = {
     {
       'tabs',
       max_length = vim.o.columns / 3, -- maximum width of tabs component
-                                      -- can also be a function that returns value of max_length dynamicaly
-      mode = 0, -- 0  shows tab_nr
-                -- 1  shows tab_name
-                -- 2  shows tab_nr + tab_name
+                                      -- can also be a function that returns value of max_length dynamically
+      mode = 0, -- 0: shows tab_nr
+                -- 1: shows tab_name
+                -- 2: shows tab_nr + tab_name
       tabs_color = {
         -- Same values like general color option can be used here.
         active = 'lualine_{section}_normal',   -- color for active tab

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ sections = {
       -- here, '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
       -- 'highlight_group_name' | {fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style'}
       --
-      -- Note: all other color options including themes accept like diff_color same color values.
+      -- Note: all other color options like diff_color including themes accept same color values
       --
       -- example:
       --   color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
@@ -474,7 +474,6 @@ sections = {
     {
       'diff',
       colored = true, -- Displays diff status in color if set to true
-      -- All colors are in #rrggbb format
       diff_color = {
         -- Same values like general color option can be used here.
         added    = 'DiffAdd',    -- Changes the diff's added color


### PR DESCRIPTION
This MR fixes a few typos I encountered while reading through lualine's documentation. 

I've also tried to reformat ~~parts~~ most of the documentation to keep the same style across the whole thing.