### PR TITLE
Enhanced readability for lualine's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ in `.vim` files by wrapping them in lua heredoc like this:
 
 ```vim
 lua << END
-require'lualine'.setup()
+require('lualine').setup()
 END
 ```
 
@@ -115,7 +115,7 @@ For more information, check out `:help lua-heredoc`.
 #### Default config
 
 ```lua
-require'lualine'.setup {
+require('lualine').setup {
   options = {
     icons_enabled = true,
     theme = 'auto',
@@ -149,7 +149,7 @@ If you want to get your current lualine config, you can
 do so with:
 
 ```lua
-require'lualine'.get_config()
+require('lualine').get_config()
 
 ```
 
@@ -158,7 +158,7 @@ require'lualine'.get_config()
 ### Starting lualine
 
 ```lua
-require'lualine'.setup()
+require('lualine').setup()
 ```
 
 ---
@@ -181,7 +181,7 @@ local custom_gruvbox = require'lualine.themes.gruvbox'
 -- Change the background of lualine_c section for normal mode
 custom_gruvbox.normal.c.bg = '#112233'
 
-require'lualine'.setup {
+require('lualine').setup {
   options = { theme  = custom_gruvbox },
   ...
 }
@@ -299,7 +299,7 @@ but you cannot use local options as global.
 Global option used locally overwrites the global, for example:
 
 ```lua
-    require'lualine'.setup {
+    require('lualine').setup {
       options = { fmt = string.lower },
       sections = { lualine_a = {
         { 'mode', fmt = function(str) return str:sub(1,1) end } },
@@ -435,7 +435,7 @@ sections = {
       }, -- Shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
 
       buffers_color = {
-        -- Same values of the general color option can be used here.
+        -- Same values as the general color option can be used here.
         active = 'lualine_{section}_normal',     -- Color for active buffer.
         inactive = 'lualine_{section}_inactive', -- Color for inactive buffer.
       },
@@ -462,7 +462,7 @@ sections = {
       sections = { 'error', 'warn', 'info', 'hint' },
 
       diagnostics_color = {
-        -- Same values of the general color option can be used here.
+        -- Same values as the general color option can be used here.
         error = 'DiagnosticError', -- Changes diagnostics' error color.
         warn  = 'DiagnosticWarn',  -- Changes diagnostics' warn color.
         info  = 'DiagnosticInfo',  -- Changes diagnostics' info color.
@@ -573,7 +573,7 @@ sections = {
                 -- 2: Shows tab_nr + tab_name
 
       tabs_color = {
-        -- Same values of the general color option can be used here.
+        -- Same values as the general color option can be used here.
         active = 'lualine_{section}_normal',     -- Color for active tab.
         inactive = 'lualine_{section}_inactive', -- Color for inactive tab.
       },
@@ -667,7 +667,7 @@ You can define your own extensions. If you believe an extension may be useful to
 
 ```lua
 local my_extension = { sections = { lualine_a = {'mode'} }, filetypes = {'lua'} }
-require'lualine'.setup { extensions = { my_extension } }
+require('lualine').setup { extensions = { my_extension } }
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here is a preview of what lualine can look like.
 
 Screenshots of all available themes are listed in [THEMES.md](./THEMES.md)
 
-For those who want to break the norms. You can create custom looks in lualine.
+For those who want to break the norms, you can create custom looks for lualine.
 
 **Example** :
 
@@ -50,7 +50,7 @@ For those who want to break the norms. You can create custom looks in lualine.
 
 ## Performance compared to other plugins
 
-Unlike other statusline plugins lualine loads only defined components, nothing else.
+Unlike other statusline plugins, lualine loads only a defined set of components, nothing else.
 
 Startup time performance measured with an amazing plugin [dstein64/vim-startuptime](https://github.com/dstein64/vim-startuptime)
 
@@ -187,16 +187,16 @@ require('lualine').setup {
 }
 ```
 
-Theme structure is available [here](https://github.com/nvim-lualine/lualine.nvim/wiki/Writting-a-theme)
+Theme structure is available [here](https://github.com/nvim-lualine/lualine.nvim/wiki/Writting-a-theme).
 
 ---
 
 ### Separators
 
-Lualine defines two kinds of separators:
+lualine defines two kinds of separators:
 
-- `section_separators` - separators between sections
-- `components_separators` - separators between components in sections
+- `section_separators`    - separators between sections
+- `components_separators` - separators between the different components in sections
 
 ```lua
 options = {
@@ -530,7 +530,6 @@ sections = {
                                -- 1: Relative path
                                -- 2: Absolute path
 
-
       shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                -- for other components. (terrible name, any suggestions?)
       symbols = {
@@ -550,7 +549,7 @@ sections = {
   lualine_a = {
     {
       'filetype',
-      colored = true, -- Displays filetype icon in color if set to true
+      colored = true,   -- Displays filetype icon in color if set to true
       icon_only = false -- Display only an icon for filetype
     }
   }
@@ -627,7 +626,7 @@ inactive_sections = {},
 ```
 
 If you want a more sophisticated tabline you can use other
-tabline plugins with lualine too. For example:
+tabline plugins with lualine too, for example:
 
 - [nvim-bufferline](https://github.com/akinsho/nvim-bufferline.lua)
 - [tabline.nvim](https://github.com/kdheepak/tabline.nvim)
@@ -639,7 +638,7 @@ You can find a bigger list [here](https://github.com/rockerBOO/awesome-neovim#ta
 
 ### Extensions
 
-Lualine extensions change statusline appearance for a window/buffer with
+lualine extensions change statusline appearance for a window/buffer with
 specified filetypes.
 
 By default no extensions are loaded to improve performance.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Plug 'kyazdani42/nvim-web-devicons'
 ```lua
 use {
   'nvim-lualine/lualine.nvim',
-  requires = {'kyazdani42/nvim-web-devicons', opt = true}
+  requires = { 'kyazdani42/nvim-web-devicons', opt = true }
 }
 ```
 
@@ -145,8 +145,8 @@ require'lualine'.setup {
 }
 ```
 
-If you want to get your current lualine config. you can
-do so with
+If you want to get your current lualine config, you can
+do so with:
 
 ```lua
 require'lualine'.get_config()
@@ -158,7 +158,7 @@ require'lualine'.get_config()
 ### Starting lualine
 
 ```lua
-require('lualine').setup()
+require'lualine'.setup()
 ```
 
 ---
@@ -166,20 +166,22 @@ require('lualine').setup()
 ### Setting a theme
 
 ```lua
-options = {theme = 'gruvbox'}
+options = { theme = 'gruvbox' }
 ```
 
 All available themes are listed in [THEMES.md](./THEMES.md)
 
-Please create a pr if you managed to port a popular theme before me, [here is how to do it](./CONTRIBUTING.md).
+Please create a PR if you managed to port a popular theme before me, [here is how to do it](./CONTRIBUTING.md).
 
 #### Customizing themes
 
 ```lua
 local custom_gruvbox = require'lualine.themes.gruvbox'
+
 -- Change the background of lualine_c section for normal mode
-custom_gruvbox.normal.c.bg = '#112233' -- RGB colors are supported
-require'lualine'.setup{
+custom_gruvbox.normal.c.bg = '#112233'
+
+require'lualine'.setup {
   options = { theme  = custom_gruvbox },
   ...
 }
@@ -198,8 +200,8 @@ Lualine defines two kinds of separators:
 
 ```lua
 options = {
-  section_separators = { left = '', right = ''},
-  component_separators = { left = '', right = ''}
+  section_separators = { left = '', right = '' },
+  component_separators = { left = '', right = '' }
 }
 ```
 
@@ -209,7 +211,7 @@ it'll be used for right sections (x, y, z).
 #### Disabling separators
 
 ```lua
-options = {section_separators = '', component_separators = ''}
+options = { section_separators = '', component_separators = '' }
 ```
 
 ---
@@ -245,19 +247,19 @@ sections = {lualine_a = {'mode'}}
 local function hello()
   return [[hello world]]
 end
-sections = {lualine_a = {hello}}
+sections = { lualine_a = { hello } }
 ```
 
 ##### Vim functions as lualine component
 
 ```lua
-sections = {lualine_a = {'FugitiveHead'}}
+sections = { lualine_a = {'FugitiveHead'} }
 ```
 
 ##### Vim's statusline items as lualine component
 
 ```lua
-sections = {lualine_c = {'%=', '%t%m', '%3p'}}
+sections = { lualine_c = {'%=', '%t%m', '%3p'} }
 ```
 
 ##### Vim variables as lualine component
@@ -267,7 +269,7 @@ Variables from `g:`, `v:`, `t:`, `w:`, `b:`, `o`, `go:`, `vo:`, `to:`, `wo:`, `b
 See `:h lua-vim-variables` and `:h lua-vim-options` if you are not sure what to use.
 
 ```lua
-sections = {lualine_a = {'g:coc_status', 'bo:filetype'}}
+sections = { lualine_a = { 'g:coc_status', 'bo:filetype' } }
 ```
 
 ##### Lua expressions as lualine component
@@ -279,7 +281,7 @@ You can use any valid lua expression as a component including
 - require statements
 
 ```lua
-sections = {lualine_c = {"os.date('%a')", 'data', "require'lsp-status'.status()"}}
+sections = { lualine_c = { "os.date('%a')", 'data', "require'lsp-status'.status()" } }
 ```
 
 `data` is a global variable in this example.
@@ -300,10 +302,10 @@ Global option used locally overwrites the global, for example:
 
 ```lua
     require'lualine'.setup {
-      options = {fmt = string.lower},
-      sections = {lualine_a = {
-        {'mode', fmt = function(str) return str:sub(1,1) end}},
-                  lualine_b = {'branch'}}
+      options = { fmt = string.lower },
+      sections = { lualine_a = {
+        { 'mode', fmt = function(str) return str:sub(1,1) end} },
+                  lualine_b = {'branch'} }
     }
 ```
 
@@ -328,9 +330,9 @@ the option value in component.
 
 ```lua
 options = {
-  theme = 'auto',              -- lualine theme
-  component_separators = {left = '', right = ''},
-  section_separators = {left = '', right = ''},
+  theme = 'auto', -- lualine theme
+  component_separators = { left = '', right = '' },
+  section_separators = { left = '', right = '' },
   disabled_filetypes = {},     -- Filetypes to disable lualine for.
   always_divide_middle = true, -- When set to true, left sections i.e. 'a','b' and 'c'
                                -- can't take over the entire statusline even
@@ -352,46 +354,51 @@ sections = {
       icon = nil,      -- Defines the icon to be displayed in front of the component.
 
       separator = nil, -- Determines what separator to use for the component.
-                       -- When a string is provided it's treated as component_separator.
-                       -- When a table is provided it's treated as section_separator.
+                       -- Note:
+                       --  When a string is provided it's treated as component_separator.
+                       --  When a table is provided it's treated as section_separator.
+                       --
                        -- These options can be used to set colored separators
                        -- around a component. 
                        --
-                       -- The options need to be set like:
+                       -- The options need to be set as such:
                        --   separator = { left = '', right = ''}
                        --
                        -- Where left will be placed on left side of component,
                        -- and right will be placed on its right.
+                       --
                        -- Passing an empty string disables the separator.
 
       cond = nil, -- Condition function, the component is loaded when the function returns `true`.
 
-      -- Custom color for the component in format
-      -- here, '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
-      -- 'highlight_group_name' | {fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style'}
+      -- Defines a custom color for the component:
       --
-      -- Note: all other color options like diff_color including themes accept same color values
+      -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
+      -- Note: 
+      --  '|' is synonymous with 'or', meaning a different acceptable format for that placeholder.
       --
-      -- example:
-      --   color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
-      --   color = {fg = 204}   -- when fg/bg is skiped they default to themes fg/bg
-      --   color = 'WarningMsg' -- highlight groups can also be used
+      -- Examples:
+      --   color = { fg = '#ffaa88', bg = 'grey', gui='italic,bold' },
+      --   color = { fg = 204 }   -- When fg/bg are omitted, they default to the your theme's fg/bg.
+      --   color = 'WarningMsg'   -- Highlight groups can also be used.
       --
-      color = nil, -- default is themes color for that section and mode
+      color = nil, -- The default is your theme's color for that section and mode.
 
-      -- This option specifies what type a component is.
-      -- When it's omitted lualine will guess it for you.
-      -- 
+      -- Specify what type a component is, if omitted, lualine will guess it for you.
+      --
       -- Available types are:
       --   [format: type_name(example)], mod(branch/filename),
       --   stl(%f/%m), var(g:coc_status/bo:modifiable),
       --   lua_expr(lua expressions), vim_fun(viml function name)
       --
-      -- lua_expr is short for lua-expression and vim_fun is short fror vim-function
+      -- Note:
+      -- lua_expr is short for lua-expression and vim_fun is short for vim-function.
       type = nil,
+
       padding = 1, -- Adds padding to the left and right of components.
                    -- Padding can be specified to left or right independently, e.g.:
                    --   padding = { left = left_padding, right = right_padding }
+
       fmt = nil,   -- Format function, formats the component's output.
     }
   }
@@ -411,11 +418,13 @@ sections = {
   lualine_a = {
     {
       'buffers',
-      show_filename_only = true,   -- Shows shortened relative path when set to false
-      show_modified_status = true, -- Shows indicator then buffer is modified
+      show_filename_only = true,   -- Shows shortened relative path when set to false.
+      show_modified_status = true, -- Shows indicator then buffer is modified.
+
       mode = 0, -- 0: Shows buffer name
                 -- 1: Shows buffer index (bufnr)
                 -- 2: Shows buffer name + buffer index (bufnr)
+
       max_length = vim.o.columns * 2 / 3, -- Maximum width of buffers component,
                                           -- it can also be a function that returns
                                           -- the value of `max_length` dynamically.
@@ -426,10 +435,11 @@ sections = {
         fzf = 'FZF',
         alpha = 'Alpha'
       }, -- Shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
+
       buffers_color = {
-        -- Same values like general color option can be used here.
-        active = 'lualine_{section}_normal',     -- Color for active buffer
-        inactive = 'lualine_{section}_inactive', -- Color for inactive buffer
+        -- Same values of the general color option can be used here.
+        active = 'lualine_{section}_normal',     -- Color for active buffer.
+        inactive = 'lualine_{section}_inactive', -- Color for inactive buffer.
       },
     }
   }
@@ -443,24 +453,27 @@ sections = {
   lualine_a = {
     {
       'diagnostics',
+
       -- Table of diagnostic sources, available sources are:
       --   'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'.
-      -- or a function that returns a table like:
-      --   {error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt}
-      sources = {'nvim_diagnostic', 'coc'},
-      -- displays diagnostics from defined severity
-      sections = {'error', 'warn', 'info', 'hint'},
+      -- or a function that returns a table as such:
+      --   { error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt }
+      sources = { 'nvim_diagnostic', 'coc' },
+
+      -- Displays diagnostics from defined severity
+      sections = { 'error', 'warn', 'info', 'hint' },
+
       diagnostics_color = {
-        -- Same values like general color option can be used here.
-        error = 'DiagnosticError', -- Changes diagnostics' error color
-        warn  = 'DiagnosticWarn',  -- Changes diagnostics' warn color
-        info  = 'DiagnosticInfo',  -- Changes diagnostics' info color
-        hint  = 'DiagnosticHint',  -- Changes diagnostics' hint color
+        -- Same values of the general color option can be used here.
+        error = 'DiagnosticError', -- Changes diagnostics' error color.
+        warn  = 'DiagnosticWarn',  -- Changes diagnostics' warn color.
+        info  = 'DiagnosticInfo',  -- Changes diagnostics' info color.
+        hint  = 'DiagnosticHint',  -- Changes diagnostics' hint color.
       },
       symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'},
-      colored = true,           -- Displays diagnostics status in color if set to true
-      update_in_insert = false, -- Update diagnostics in insert mode
-      always_visible = false,   -- Show diagnostics even if there are none
+      colored = true,           -- Displays diagnostics status in color if set to true.
+      update_in_insert = false, -- Update diagnostics in insert mode.
+      always_visible = false,   -- Show diagnostics even if there are none.
     }
   }
 }
@@ -473,17 +486,17 @@ sections = {
   lualine_a = {
     {
       'diff',
-      colored = true, -- Displays diff status in color if set to true
+      colored = true, -- Displays a colored diff status if set to true
       diff_color = {
-        -- Same values like general color option can be used here.
+        -- Same color values as the general color option can be used here.
         added    = 'DiffAdd',    -- Changes the diff's added color
         modified = 'DiffChange', -- Changes the diff's modified color
         removed  = 'DiffDelete', -- Changes the diff's removed color you
       },
       symbols = {added = '+', modified = '~', removed = '-'}, -- Changes the symbols used by the diff
       source = nil, -- A function that works as a data source for diff.
-                    -- It must return a table like:
-                    --   {added = add_count, modified = modified_count, removed = removed_count }
+                    -- It must return a table as such:
+                    --   { added = add_count, modified = modified_count, removed = removed_count }
                     -- or nil on failure. count <= 0 won't be displayed.
     }
   }
@@ -514,14 +527,14 @@ sections = {
   lualine_a = {
     {
       'filename',
-      file_status = true, -- Displays file status (readonly status, modified status)
-      path = 0,           -- 0: Just the filename
-                          -- 1: Relative path
-                          -- 2: Absolute path
+      file_status = true,      -- Displays file status (readonly status, modified status)
+      path = 0,                -- 0: Just the filename
+                               -- 1: Relative path
+                               -- 2: Absolute path
 
 
-      shorting_target = 40, -- Shortens path to leave 40 spaces in the window
-                            -- for other components. (terrible name, any suggestions?)
+      shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
+                               -- for other components. (terrible name, any suggestions?)
       symbols = {
         modified = '[+]',      -- Text to show when the file is modified
         readonly = '[-]',      -- Text to show when the file is non-modifiable or readonly
@@ -553,17 +566,18 @@ sections = {
   lualine_a = {
     {
       'tabs',
-      max_length = vim.o.columns / 3, -- Maximum width of tabs component,
-                                      -- it can also be a function that returns 
+      max_length = vim.o.columns / 3, -- Maximum width of tabs component.
+                                      -- Note:
+                                      -- It can also be a function that returns 
                                       -- the value of `max_length` dynamically.
       mode = 0, -- 0: Shows tab_nr
                 -- 1: Shows tab_name
                 -- 2: Shows tab_nr + tab_name
 
       tabs_color = {
-        -- Same values like general color option can be used here.
-        active = 'lualine_{section}_normal',   -- color for active tab
-        inactive = 'lualine_{section}_inactive', -- color for inactive tab
+        -- Same values of the general color option can be used here.
+        active = 'lualine_{section}_normal',     -- Color for active tab.
+        inactive = 'lualine_{section}_inactive', -- Color for inactive tab.
       },
     }
   }
@@ -654,8 +668,8 @@ extensions = {'quickfix'}
 You can define your own extensions. If you think an extension might be useful for others then please submit a pr.
 
 ```lua
-local my_extension = {sections = {lualine_a = {'mode'}}, filetypes = {'lua'}}
-require'lualine'.setup {extensions = {my_extension}}
+local my_extension = { sections = { lualine_a = {'mode'} }, filetypes = {'lua'} }
+require'lualine'.setup { extensions = { my_extension } }
 ```
 
 ---
@@ -665,7 +679,7 @@ require'lualine'.setup {extensions = {my_extension}}
 You can disable lualine for specific filetypes
 
 ```lua
-options = {disabled_filetypes = {'lua'}}
+options = { disabled_filetypes = {'lua'} }
 ```
 
 <!-- panvimdoc-ignore-start -->

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Please create a pr if you managed to port a popular theme before me, [here is ho
 ```lua
 local custom_gruvbox = require'lualine.themes.gruvbox'
 -- Change the background of lualine_c section for normal mode
-custom_gruvbox.normal.c.bg = '#112233' -- rgb colors are supported
+custom_gruvbox.normal.c.bg = '#112233' -- RGB colors are supported
 require'lualine'.setup{
   options = { theme  = custom_gruvbox },
   ...
@@ -331,10 +331,10 @@ options = {
   theme = 'auto',              -- lualine theme
   component_separators = {left = '', right = ''},
   section_separators = {left = '', right = ''},
-  disabled_filetypes = {},     -- filetypes to disable lualine for
-  always_divide_middle = true, -- when set to true, left_sections (a,b,c)
-                               -- can't take over entire statusline even if
-                               -- neither of 'x', 'y' or 'z' are present.
+  disabled_filetypes = {},     -- Filetypes to disable lualine for.
+  always_divide_middle = true, -- When set to true, left sections i.e. 'a','b' and 'c'
+                               -- can't take over the entire statusline even
+                               -- if neither of 'x', 'y' or 'z' are present.
 }
 ```
 
@@ -348,43 +348,51 @@ sections = {
   lualine_a = {
     {
       'mode',
-      icons_enabled = true, -- enables the display of icons alongside the component.
-      icon = nil,      -- defines the icon to be displayed in front of the component.
-      separator = nil, -- determines what separator to use for the component.
-                       -- when a string is given it's treated as component_separator.
-                       -- when a table is given it's treated as section_separator.
-                       -- these options can be used to set colored separators
-                       -- around a component. The options need to be set like
-                       -- `separator = { left = '', right = ''}`.
-                       -- where left will be placed on left side of component
-                       -- and right will be placed on right side of component.
-                       -- passing an empty string disables that separator.
-      cond = nil, -- condition function, component is loaded when the function returns true
-      -- custom color for the component in format
-      -- here '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
+      icons_enabled = true, -- Enables the display of icons alongside the component.
+      icon = nil,      -- Defines the icon to be displayed in front of the component.
+
+      separator = nil, -- Determines what separator to use for the component.
+                       -- When a string is provided it's treated as component_separator.
+                       -- When a table is provided it's treated as section_separator.
+                       -- These options can be used to set colored separators
+                       -- around a component. 
+                       --
+                       -- The options need to be set like:
+                       --   separator = { left = '', right = ''}
+                       --
+                       -- Where left will be placed on left side of component,
+                       -- and right will be placed on its right.
+                       -- Passing an empty string disables the separator.
+
+      cond = nil, -- Condition function, the component is loaded when the function returns `true`.
+
+      -- Custom color for the component in format
+      -- here, '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
       -- 'highlight_group_name' | {fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style'}
       --
-      -- note: all other color options including themes accept like diff_color same color values.
+      -- Note: all other color options including themes accept like diff_color same color values.
       --
       -- example:
       --   color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
-      --   color = {fg = 204} -- when fg/bg is skiped they default to themes fg/bg
-      --   color = 'WarningMsg'
+      --   color = {fg = 204}   -- when fg/bg is skiped they default to themes fg/bg
+      --   color = 'WarningMsg' -- highlight groups can also be used
       --
-      -- or highlight group
-      -- color = "WarningMsg"
       color = nil, -- default is themes color for that section and mode
-      -- Type option specifies what type a component is.
-      -- When type is omitted lualine will guess it.
-      -- Available types [format: type_name(example)]
-      -- mod(branch/filename), stl(%f/%m), var(g:coc_status/bo:modifiable),
-      -- lua_expr(lua expressions), vim_fun(viml function name)
+
+      -- This option specifies what type a component is.
+      -- When it's omitted lualine will guess it for you.
+      -- 
+      -- Available types are:
+      --   [format: type_name(example)], mod(branch/filename),
+      --   stl(%f/%m), var(g:coc_status/bo:modifiable),
+      --   lua_expr(lua expressions), vim_fun(viml function name)
+      --
       -- lua_expr is short for lua-expression and vim_fun is short fror vim-function
       type = nil,
-      padding = 1, -- adds padding to the left and right of components
-                   -- padding can be specified to left or right separately like
-                   -- padding = { left = left_padding, right = right_padding }
-      fmt = nil,   -- format function, formats the component's output
+      padding = 1, -- Adds padding to the left and right of components.
+                   -- Padding can be specified to left or right independently, e.g.:
+                   --   padding = { left = left_padding, right = right_padding }
+      fmt = nil,   -- Format function, formats the component's output.
     }
   }
 }
@@ -403,24 +411,25 @@ sections = {
   lualine_a = {
     {
       'buffers',
-      show_filename_only = true,   -- shows shortened relative path when false
-      show_modified_status = true, -- shows indicator then buffer is modified
-      mode = 0, -- 0: shows buffer name
-                -- 1: shows buffer index (bufnr)
-                -- 2: shows buffer name + buffer index (bufnr)
-      max_length = vim.o.columns * 2 / 3, -- maximum width of buffers component
-                                          -- can also be a function that returns value of max_length dynamically
+      show_filename_only = true,   -- Shows shortened relative path when set to false
+      show_modified_status = true, -- Shows indicator then buffer is modified
+      mode = 0, -- 0: Shows buffer name
+                -- 1: Shows buffer index (bufnr)
+                -- 2: Shows buffer name + buffer index (bufnr)
+      max_length = vim.o.columns * 2 / 3, -- Maximum width of buffers component,
+                                          -- it can also be a function that returns
+                                          -- the value of `max_length` dynamically.
       filetype_names = {
         TelescopePrompt = 'Telescope',
         dashboard = 'Dashboard',
         packer = 'Packer',
         fzf = 'FZF',
         alpha = 'Alpha'
-      }, -- shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
+      }, -- Shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
       buffers_color = {
         -- Same values like general color option can be used here.
-        active = 'lualine_{section}_normal',     -- color for active buffer
-        inactive = 'lualine_{section}_inactive', -- color for inactive buffer
+        active = 'lualine_{section}_normal',     -- Color for active buffer
+        inactive = 'lualine_{section}_inactive', -- Color for inactive buffer
       },
     }
   }
@@ -434,8 +443,8 @@ sections = {
   lualine_a = {
     {
       'diagnostics',
-      -- table of diagnostic sources, available sources:
-      -- 'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'
+      -- Table of diagnostic sources, available sources are:
+      --   'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'.
       -- or a function that returns a table like:
       --   {error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt}
       sources = {'nvim_diagnostic', 'coc'},
@@ -443,15 +452,15 @@ sections = {
       sections = {'error', 'warn', 'info', 'hint'},
       diagnostics_color = {
         -- Same values like general color option can be used here.
-        error = 'DiagnosticError', -- changes diagnostic's error color
-        warn  = 'DiagnosticWarn',  -- changes diagnostic's warn color
-        info  = 'DiagnosticInfo',  -- changes diagnostic's info color
-        hint  = 'DiagnosticHint',  -- changes diagnostic's hint color
+        error = 'DiagnosticError', -- Changes diagnostics' error color
+        warn  = 'DiagnosticWarn',  -- Changes diagnostics' warn color
+        info  = 'DiagnosticInfo',  -- Changes diagnostics' info color
+        hint  = 'DiagnosticHint',  -- Changes diagnostics' hint color
       },
       symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'},
-      colored = true,           -- displays diagnostics status in color if set to true
-      update_in_insert = false, -- update diagnostics in insert mode
-      always_visible = false,   -- show diagnostics even if count is 0, boolean or function returning boolean
+      colored = true,           -- Displays diagnostics status in color if set to true
+      update_in_insert = false, -- Update diagnostics in insert mode
+      always_visible = false,   -- Show diagnostics even if there are none
     }
   }
 }
@@ -464,17 +473,17 @@ sections = {
   lualine_a = {
     {
       'diff',
-      colored = true, -- displays diff status in color if set to true
-      -- all colors are in format #rrggbb
+      colored = true, -- Displays diff status in color if set to true
+      -- All colors are in #rrggbb format
       diff_color = {
         -- Same values like general color option can be used here.
-        added    = 'DiffAdd',    -- changes diff's added color
-        modified = 'DiffChange', -- changes diff's modified color
-        removed  = 'DiffDelete', -- changes diff's removed color you
+        added    = 'DiffAdd',    -- Changes the diff's added color
+        modified = 'DiffChange', -- Changes the diff's modified color
+        removed  = 'DiffDelete', -- Changes the diff's removed color you
       },
-      symbols = {added = '+', modified = '~', removed = '-'}, -- changes diff symbols
-      source = nil, -- a function that works as a data source for diff.
-                    -- it must return a table like:
+      symbols = {added = '+', modified = '~', removed = '-'}, -- Changes the symbols used by the diff
+      source = nil, -- A function that works as a data source for diff.
+                    -- It must return a table like:
                     --   {added = add_count, modified = modified_count, removed = removed_count }
                     -- or nil on failure. count <= 0 won't be displayed.
     }
@@ -506,18 +515,18 @@ sections = {
   lualine_a = {
     {
       'filename',
-      file_status = true, -- displays file status (readonly status, modified status)
-      path = 0,           -- 0: just filename
-                          -- 1: relative path
-                          -- 2: absolute path
+      file_status = true, -- Displays file status (readonly status, modified status)
+      path = 0,           -- 0: Just the filename
+                          -- 1: Relative path
+                          -- 2: Absolute path
 
 
-      shorting_target = 40, -- shortens path to leave 40 spaces in the window
+      shorting_target = 40, -- Shortens path to leave 40 spaces in the window
                             -- for other components. (terrible name, any suggestions?)
       symbols = {
-        modified = '[+]',      -- text to show when the file is modified
-        readonly = '[-]',      -- text to show when the file is non-modifiable or readonly
-        unnamed = '[No Name]', -- text to show for unnamed buffers
+        modified = '[+]',      -- Text to show when the file is modified
+        readonly = '[-]',      -- Text to show when the file is non-modifiable or readonly
+        unnamed = '[No Name]', -- Text to show for unnamed buffers
       }
     }
   }
@@ -531,8 +540,8 @@ sections = {
   lualine_a = {
     {
       'filetype',
-      colored = true, -- displays filetype icon in color if set to true
-      icon_only = false -- display only an icon for filetype
+      colored = true, -- Displays filetype icon in color if set to true
+      icon_only = false -- Display only an icon for filetype
     }
   }
 }
@@ -545,11 +554,13 @@ sections = {
   lualine_a = {
     {
       'tabs',
-      max_length = vim.o.columns / 3, -- maximum width of tabs component
-                                      -- can also be a function that returns value of max_length dynamically
-      mode = 0, -- 0: shows tab_nr
-                -- 1: shows tab_name
-                -- 2: shows tab_nr + tab_name
+      max_length = vim.o.columns / 3, -- Maximum width of tabs component,
+                                      -- it can also be a function that returns 
+                                      -- the value of `max_length` dynamically.
+      mode = 0, -- 0: Shows tab_nr
+                -- 1: Shows tab_name
+                -- 2: Shows tab_nr + tab_name
+
       tabs_color = {
         -- Same values like general color option can be used here.
         active = 'lualine_{section}_normal',   -- color for active tab

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ extensions = {'quickfix'}
 
 #### Custom extensions
 
-You can define your own extensions. If you think an extension might be useful for others, then please submit a PR.
+You can define your own extensions. If you believe an extension may be useful to others, then please submit a PR.
 
 ```lua
 local my_extension = { sections = { lualine_a = {'mode'} }, filetypes = {'lua'} }
@@ -684,7 +684,7 @@ options = { disabled_filetypes = {'lua'} }
 
 ### Contributors
 
-Thanks to these wonderful people we enjoy this awesome plugin.
+Thanks to these wonderful people, we enjoy this awesome plugin.
 
 <a href="https://github.com/nvim-lualine/lualine.nvim/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=nvim-lualine/lualine.nvim" />

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For those who want to break the norms, you can create custom looks for lualine.
 
 ## Performance compared to other plugins
 
-Unlike other statusline plugins, lualine loads only a defined set of components, nothing else.
+Unlike other statusline plugins, lualine loads only the components you specify, and nothing else.
 
 Startup time performance measured with an amazing plugin [dstein64/vim-startuptime](https://github.com/dstein64/vim-startuptime)
 
@@ -187,7 +187,7 @@ require('lualine').setup {
 }
 ```
 
-Theme structure is available [here](https://github.com/nvim-lualine/lualine.nvim/wiki/Writting-a-theme).
+Theme structure is available [here](https://github.com/nvim-lualine/lualine.nvim/wiki/Writing-a-theme).
 
 ---
 
@@ -372,7 +372,7 @@ sections = {
       -- Defines a custom color for the component:
       --
       -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
-      -- Note: 
+      -- Note:
       --  '|' is synonymous with 'or', meaning a different acceptable format for that placeholder.
       --
       -- Examples:
@@ -565,7 +565,7 @@ sections = {
       'tabs',
       max_length = vim.o.columns / 3, -- Maximum width of tabs component.
                                       -- Note:
-                                      -- It can also be a function that returns 
+                                      -- It can also be a function that returns
                                       -- the value of `max_length` dynamically.
       mode = 0, -- 0: Shows tab_nr
                 -- 1: Shows tab_name

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Global option used locally overwrites the global, for example:
     require'lualine'.setup {
       options = { fmt = string.lower },
       sections = { lualine_a = {
-        { 'mode', fmt = function(str) return str:sub(1,1) end} },
+        { 'mode', fmt = function(str) return str:sub(1,1) end } },
                   lualine_b = {'branch'} }
     }
 ```
@@ -351,25 +351,25 @@ sections = {
     {
       'mode',
       icons_enabled = true, -- Enables the display of icons alongside the component.
-      icon = nil,      -- Defines the icon to be displayed in front of the component.
+      icon = nil,           -- Defines the icon to be displayed in front of the component.
 
-      separator = nil, -- Determines what separator to use for the component.
-                       -- Note:
-                       --  When a string is provided it's treated as component_separator.
-                       --  When a table is provided it's treated as section_separator.
-                       --
-                       -- These options can be used to set colored separators
-                       -- around a component. 
-                       --
-                       -- The options need to be set as such:
-                       --   separator = { left = '', right = ''}
-                       --
-                       -- Where left will be placed on left side of component,
-                       -- and right will be placed on its right.
-                       --
-                       -- Passing an empty string disables the separator.
+      separator = nil,      -- Determines what separator to use for the component.
+                            -- Note:
+                            --  When a string is provided it's treated as component_separator.
+                            --  When a table is provided it's treated as section_separator.
+                            --  Passing an empty string disables the separator.
+                            --
+                            -- These options can be used to set colored separators
+                            -- around a component. 
+                            --
+                            -- The options need to be set as such:
+                            --   separator = { left = '', right = ''}
+                            --
+                            -- Where left will be placed on left side of component,
+                            -- and right will be placed on its right.
+                            --
 
-      cond = nil, -- Condition function, the component is loaded when the function returns `true`.
+      cond = nil,           -- Condition function, the component is loaded when the function returns `true`.
 
       -- Defines a custom color for the component:
       --
@@ -419,7 +419,7 @@ sections = {
     {
       'buffers',
       show_filename_only = true,   -- Shows shortened relative path when set to false.
-      show_modified_status = true, -- Shows indicator then buffer is modified.
+      show_modified_status = true, -- Shows indicator when the buffer is modified.
 
       mode = 0, -- 0: Shows buffer name
                 -- 1: Shows buffer index (bufnr)
@@ -460,7 +460,7 @@ sections = {
       --   { error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt }
       sources = { 'nvim_diagnostic', 'coc' },
 
-      -- Displays diagnostics from defined severity
+      -- Displays diagnostics for the defined severity types
       sections = { 'error', 'warn', 'info', 'hint' },
 
       diagnostics_color = {
@@ -493,7 +493,7 @@ sections = {
         modified = 'DiffChange', -- Changes the diff's modified color
         removed  = 'DiffDelete', -- Changes the diff's removed color you
       },
-      symbols = {added = '+', modified = '~', removed = '-'}, -- Changes the symbols used by the diff
+      symbols = {added = '+', modified = '~', removed = '-'}, -- Changes the symbols used by the diff.
       source = nil, -- A function that works as a data source for diff.
                     -- It must return a table as such:
                     --   { added = add_count, modified = modified_count, removed = removed_count }
@@ -536,9 +536,9 @@ sections = {
       shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                -- for other components. (terrible name, any suggestions?)
       symbols = {
-        modified = '[+]',      -- Text to show when the file is modified
-        readonly = '[-]',      -- Text to show when the file is non-modifiable or readonly
-        unnamed = '[No Name]', -- Text to show for unnamed buffers
+        modified = '[+]',      -- Text to show when the file is modified.
+        readonly = '[-]',      -- Text to show when the file is non-modifiable or readonly.
+        unnamed = '[No Name]', -- Text to show for unnamed buffers.
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ END
 
 For more information, check out `:help lua-heredoc`.
 
-#### Default config
+#### Default configuration
 
 ```lua
 require('lualine').setup {

--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@
 
 <!-- panvimdoc-ignore-end -->
 
-A blazing fast and easy to configure Neovim statusline written in Lua
+A blazing fast and easy to configure Neovim statusline written in Lua.
 
-`lualine.nvim` requires neovim 0.5
+`lualine.nvim` requires Neovim >= 0.5.
 
 ## Contributing
 
-Feel free to create an issue/pr if you want to see anything else implemented.
-If you have some question or need help with configuration start a [discussion](https://github.com/nvim-lualine/lualine.nvim/discussions).
+Feel free to create an issue/PR if you want to see anything else implemented.
+If you have some question or need help with configuration, start a [discussion](https://github.com/nvim-lualine/lualine.nvim/discussions).
 
-Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pr.
-You can also help with documentation in [wiki](https://github.com/nvim-lualine/lualine.nvim/wiki)
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR.
+You can also help with documentation in the [wiki](https://github.com/nvim-lualine/lualine.nvim/wiki).
 
 <!-- panvimdoc-ignore-start -->
 
 ## Screenshots
 
-Here is a preview of how lualine can look like.
+Here is a preview of what lualine can look like.
 
 <p>
 <img width='700' src='https://user-images.githubusercontent.com/41551030/108650373-bb025580-74bf-11eb-8682-2c09321dd18e.png'/>
@@ -54,11 +54,11 @@ Unlike other statusline plugins lualine loads only defined components, nothing e
 
 Startup time performance measured with an amazing plugin [dstein64/vim-startuptime](https://github.com/dstein64/vim-startuptime)
 
-All times are measured with clean `init.vim` with only `vim-startuptime`,
+Times are measured with a clean `init.vim` with only `vim-startuptime`,
 `vim-plug` and given statusline plugin installed.
 In control just `vim-startuptime` and`vim-plug` is installed.
 And measured time is complete startuptime of vim not time spent
-on specific plugin. These numbers are average of 20 runs.
+on specific plugin. These numbers are the average of 20 runs.
 
 | control  |  lualine  | lightline |  airline  |
 | :------: | :-------: | :-------: | :-------: |
@@ -97,12 +97,12 @@ Lualine has sections as shown below.
 +-------------------------------------------------+
 ```
 
-Each sections holds it's components e.g. current vim's mode.
+Each sections holds its components e.g. Vim's current mode.
 
 #### Configuring lualine in init.vim
 
 All the examples below are in lua. You can use the same examples
-in `.vim` file by wrapping them in lua heredoc like this:
+in `.vim` files by wrapping them in lua heredoc like this:
 
 ```vim
 lua << END
@@ -110,7 +110,7 @@ require'lualine'.setup()
 END
 ```
 
-checkout `:help lua-heredoc`.
+For more information, check out `:help lua-heredoc`.
 
 #### Default config
 
@@ -169,9 +169,9 @@ require'lualine'.setup()
 options = { theme = 'gruvbox' }
 ```
 
-All available themes are listed in [THEMES.md](./THEMES.md)
+All available themes are listed in [THEMES.md](./THEMES.md).
 
-Please create a PR if you managed to port a popular theme before me, [here is how to do it](./CONTRIBUTING.md).
+Please create a PR if you managed to port a popular theme before us, [here is how to do it](./CONTRIBUTING.md).
 
 #### Customizing themes
 
@@ -205,8 +205,8 @@ options = {
 }
 ```
 
-Here left means it'll be used for left sections (a, b, c) and right means
-it'll be used for right sections (x, y, z).
+Here, left refers to the left-most sections (a, b, c), and right refers
+to the right-most sections (x, y, z).
 
 #### Disabling separators
 
@@ -226,7 +226,7 @@ sections = {lualine_a = {'mode'}}
 
 - `branch` (git branch)
 - `buffers` (shows currently available buffers)
-- `diagnostics` (diagnostics count from your prefered source)
+- `diagnostics` (diagnostics count from your preferred source)
 - `diff` (git diff status)
 - `encoding` (file encoding)
 - `fileformat` (file format)
@@ -274,8 +274,7 @@ sections = { lualine_a = { 'g:coc_status', 'bo:filetype' } }
 
 ##### Lua expressions as lualine component
 
-You can use any valid lua expression as a component including
-
+You can use any valid lua expression as a component including:
 - oneliners
 - global variables
 - require statements
@@ -292,7 +291,6 @@ sections = { lualine_c = { "os.date('%a')", 'data', "require'lsp-status'.status(
 
 Component options can change the way a component behave.
 There are two kinds of options:
-
 - global options affecting all components
 - local options affecting specific
 
@@ -411,7 +409,7 @@ These are options that are available on specific components.
 For example you have option on `diagnostics` component to
 specify what your diagnostic sources will be.
 
-#### buffers component options
+#### `buffers` component options
 
 ```lua
 sections = {
@@ -446,7 +444,7 @@ sections = {
 }
 ```
 
-#### diagnostics component options
+#### `diagnostics` component options
 
 ```lua
 sections = {
@@ -479,7 +477,7 @@ sections = {
 }
 ```
 
-#### diff component options
+#### `diff` component options
 
 ```lua
 sections = {
@@ -503,7 +501,7 @@ sections = {
 }
 ```
 
-#### fileformat component options
+#### `fileformat` component options
 
 ```lua
 sections = {
@@ -520,7 +518,7 @@ sections = {
 }
 ```
 
-#### filename component options
+#### `filename` component options
 
 ```lua
 sections = {
@@ -545,7 +543,7 @@ sections = {
 }
 ```
 
-#### filetype component options
+#### `filetype` component options
 
 ```lua
 sections = {
@@ -559,7 +557,7 @@ sections = {
 }
 ```
 
-#### tabs component options
+#### `tabs` component options
 
 ```lua
 sections = {
@@ -589,7 +587,7 @@ sections = {
 ### Tabline
 
 You can use lualine to display components in tabline.
-The configuration for tabline sections is exactly the same as for statusline.
+The configuration for tabline sections is exactly the same as that of the statusline.
 
 ```lua
 tabline = {
@@ -602,9 +600,9 @@ tabline = {
 }
 ```
 
-This will show branch and filename component in top of neovim inside tabline .
+This will show the branch and filename components on top of neovim inside tabline.
 
-lualine also provides 2 components buffers & tabs that you can use to get more traditional tabline/bufferline.
+lualine also provides 2 components, buffers and tabs, that you can use to get a more traditional tabline/bufferline.
 
 ```lua
 tabline = {
@@ -617,8 +615,8 @@ tabline = {
 }
 ```
 
-You can also completely move your statusline to tabline by configuring
-`lualine.tabline` and disabling `lualine.sections` and `lualine.inactive_sections`.
+You can also completely move your statusline to a tabline by configuring
+`lualine.tabline` and disabling `lualine.sections` and `lualine.inactive_sections`:
 
 ```lua
 tabline = {
@@ -629,13 +627,13 @@ inactive_sections = {},
 ```
 
 If you want a more sophisticated tabline you can use other
-tabline plugins with lualine too . For example:
+tabline plugins with lualine too. For example:
 
 - [nvim-bufferline](https://github.com/akinsho/nvim-bufferline.lua)
 - [tabline.nvim](https://github.com/kdheepak/tabline.nvim)
 
-tabline.nvim even uses lualines theme by default 🙌
-You can find a bigger list [here](https://github.com/rockerBOO/awesome-neovim#tabline)
+tabline.nvim even uses lualine's theme by default 🙌
+You can find a bigger list [here](https://github.com/rockerBOO/awesome-neovim#tabline).
 
 ---
 
@@ -665,7 +663,7 @@ extensions = {'quickfix'}
 
 #### Custom extensions
 
-You can define your own extensions. If you think an extension might be useful for others then please submit a pr.
+You can define your own extensions. If you think an extension might be useful for others, then please submit a PR.
 
 ```lua
 local my_extension = { sections = { lualine_a = {'mode'} }, filetypes = {'lua'} }
@@ -676,7 +674,7 @@ require'lualine'.setup { extensions = { my_extension } }
 
 ### Disabling lualine
 
-You can disable lualine for specific filetypes
+You can disable lualine for specific filetypes:
 
 ```lua
 options = { disabled_filetypes = {'lua'} }
@@ -694,11 +692,11 @@ Thanks to these wonderful people we enjoy this awesome plugin.
 
 ### Wiki
 
-Check out the [wiki](https://github.com/nvim-lualine/lualine.nvim/wiki) for more info .
+Check out the [wiki](https://github.com/nvim-lualine/lualine.nvim/wiki) for more info.
 
-You can find some useful [configuration snippets](https://github.com/nvim-lualine/lualine.nvim/wiki/Component-snippets) here. You can also share your awesome snippents with others.
+You can find some useful [configuration snippets](https://github.com/nvim-lualine/lualine.nvim/wiki/Component-snippets) here. You can also share your awesome snippets with others.
 
-If you want to extened lualine with plugins or want to know
-which ones already do [wiki/plugins](https://github.com/nvim-lualine/lualine.nvim/wiki/Plugins) is for you.
+If you want to extend lualine with plugins or want to know
+which ones already do, [wiki/plugins](https://github.com/nvim-lualine/lualine.nvim/wiki/Plugins) is for you.
 
 <!-- panvimdoc-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -328,13 +328,13 @@ the option value in component.
 
 ```lua
 options = {
-  theme = 'auto',          -- lualine theme
+  theme = 'auto',              -- lualine theme
   component_separators = {left = '', right = ''},
   section_separators = {left = '', right = ''},
-  disabled_filetypes = {},  -- filetypes to disable lualine on
-  always_divide_middle = true, -- When true left_sections (a,b,c) can't
-                               -- take over entiee statusline even
-                               -- when none of section x, y, z is present.
+  disabled_filetypes = {},     -- filetypes to disable lualine for
+  always_divide_middle = true, -- when set to true, left_sections (a,b,c)
+                               -- can't take over entire statusline even if
+                               -- neither of 'x', 'y' or 'z' are present.
 }
 ```
 
@@ -348,26 +348,29 @@ sections = {
   lualine_a = {
     {
       'mode',
-      icons_enabled = true, -- displays icons in alongside component
-      icon = nil,      -- displays icon in front of the component
-      separator = nil, -- Determines what separator to use for the component.
+      icons_enabled = true, -- enables the display of icons alongside the component.
+      icon = nil,      -- defines the icon to be displayed in front of the component.
+      separator = nil, -- determines what separator to use for the component.
                        -- when a string is given it's treated as component_separator.
-                       -- When a table is given it's treated as section_separator.
-                       -- This options can be used to set colored separators
-                       -- arround component. Option need to be set like
+                       -- when a table is given it's treated as section_separator.
+                       -- these options can be used to set colored separators
+                       -- around a component. The options need to be set like
                        -- `separator = { left = '', right = ''}`.
-                       -- Where left will be placed in left side of component
-                       -- and right will be placed in right side of component
-                       -- Passing empty string disables that separator
-      cond = nil, -- condition function, component is loaded when function returns true
+                       -- where left will be placed on left side of component
+                       -- and right will be placed on right side of component.
+                       -- passing an empty string disables that separator.
+      cond = nil, -- condition function, component is loaded when the function returns true
       -- custom color for the component in format
-      -- here '|' refers to or meaning a different acceptable format for that placeholder
+      -- here '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
       -- 'highlight_group_name' | {fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style'}
-      --  Note: all other color options including themes accept  like diff_color same color values
-      -- Example
-      -- color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
-      -- color = {fg = 204} -- when fg/bg is skiped they default to themes fg/bg
-      -- color = 'WarningMsg'
+      --
+      -- note: all other color options including themes accept like diff_color same color values.
+      --
+      -- example:
+      --   color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
+      --   color = {fg = 204} -- when fg/bg is skiped they default to themes fg/bg
+      --   color = 'WarningMsg'
+      --
       -- or highlight group
       -- color = "WarningMsg"
       color = nil, -- default is themes color for that section and mode
@@ -381,7 +384,7 @@ sections = {
       padding = 1, -- adds padding to the left and right of components
                    -- padding can be specified to left or right separately like
                    -- padding = { left = left_padding, right = right_padding }
-      fmt = nil,   -- format function, formats component's output
+      fmt = nil,   -- format function, formats the component's output
     }
   }
 }
@@ -400,13 +403,13 @@ sections = {
   lualine_a = {
     {
       'buffers',
-      show_filename_only = true, -- shows shortened relative path when false
+      show_filename_only = true,   -- shows shortened relative path when false
       show_modified_status = true, -- shows indicator then buffer is modified
-      mode = 0, -- 0 shows buffer name
-                -- 1 buffer index (bufnr)
-                -- 2 shows buffer name + buffer index (bufnr)
+      mode = 0, -- 0: shows buffer name
+                -- 1: shows buffer index (bufnr)
+                -- 2: shows buffer name + buffer index (bufnr)
       max_length = vim.o.columns * 2 / 3, -- maximum width of buffers component
-                                          -- can also be a function that returns value of max_length dynamicaly
+                                          -- can also be a function that returns value of max_length dynamically
       filetype_names = {
         TelescopePrompt = 'Telescope',
         dashboard = 'Dashboard',
@@ -416,7 +419,7 @@ sections = {
       }, -- shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
       buffers_color = {
         -- Same values like general color option can be used here.
-        active = 'lualine_{section}_normal', -- color for active buffer
+        active = 'lualine_{section}_normal',     -- color for active buffer
         inactive = 'lualine_{section}_inactive', -- color for inactive buffer
       },
     }
@@ -433,7 +436,7 @@ sections = {
       'diagnostics',
       -- table of diagnostic sources, available sources:
       -- 'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'
-      -- Or a function that returns a table like
+      -- or a function that returns a table like:
       --   {error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt}
       sources = {'nvim_diagnostic', 'coc'},
       -- displays diagnostics from defined severity
@@ -446,9 +449,9 @@ sections = {
         hint  = 'DiagnosticHint',  -- changes diagnostic's hint color
       },
       symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'},
-      colored = true, -- displays diagnostics status in color if set to true
-      update_in_insert = false, -- Update diagnostics in insert mode
-      always_visible = false, -- Show diagnostics even if count is 0, boolean or function returning boolean
+      colored = true,           -- displays diagnostics status in color if set to true
+      update_in_insert = false, -- update diagnostics in insert mode
+      always_visible = false,   -- show diagnostics even if count is 0, boolean or function returning boolean
     }
   }
 }
@@ -470,10 +473,10 @@ sections = {
         removed  = 'DiffDelete', -- changes diff's removed color you
       },
       symbols = {added = '+', modified = '~', removed = '-'}, -- changes diff symbols
-      source = nil, -- A function that works as a data source for diff.
-                    -- it must return a table like
-                    -- {added = add_count, modified = modified_count, removed = removed_count }
-                    -- Or nil on failure. Count <= 0 won't be displayed.
+      source = nil, -- a function that works as a data source for diff.
+                    -- it must return a table like:
+                    --   {added = add_count, modified = modified_count, removed = removed_count }
+                    -- or nil on failure. count <= 0 won't be displayed.
     }
   }
 }
@@ -488,8 +491,8 @@ sections = {
       'fileformat',
       symbols = {
         unix = '', -- e712
-        dos = '', -- e70f
-        mac = '', -- e711
+        dos = '',  -- e70f
+        mac = '',  -- e711
       }
     }
   }
@@ -503,14 +506,18 @@ sections = {
   lualine_a = {
     {
       'filename',
-      file_status = true,   -- displays file status (readonly status, modified status)
-      path = 0,             -- 0 = just filename, 1 = relative path, 2 = absolute path
-      shorting_target = 40, -- Shortens path to leave 40 space in the window
-                            -- for other components. Terrible name any suggestions?
+      file_status = true, -- displays file status (readonly status, modified status)
+      path = 0,           -- 0: just filename
+                          -- 1: relative path
+                          -- 2: absolute path
+
+
+      shorting_target = 40, -- shortens path to leave 40 spaces in the window
+                            -- for other components. (terrible name, any suggestions?)
       symbols = {
-        modified = '[+]',      -- when the file was modified
-        readonly = '[-]',      -- if the file is not modifiable or readonly
-        unnamed = '[No Name]', -- default display name for unnamed buffers
+        modified = '[+]',      -- text to show when the file is modified
+        readonly = '[-]',      -- text to show when the file is non-modifiable or readonly
+        unnamed = '[No Name]', -- text to show for unnamed buffers
       }
     }
   }
@@ -524,8 +531,8 @@ sections = {
   lualine_a = {
     {
       'filetype',
-      colored = true, -- displays filetype icon in color if set to `true
-      icon_only = false -- Display only icon for filetype
+      colored = true, -- displays filetype icon in color if set to true
+      icon_only = false -- display only an icon for filetype
     }
   }
 }
@@ -539,10 +546,10 @@ sections = {
     {
       'tabs',
       max_length = vim.o.columns / 3, -- maximum width of tabs component
-                                      -- can also be a function that returns value of max_length dynamicaly
-      mode = 0, -- 0  shows tab_nr
-                -- 1  shows tab_name
-                -- 2  shows tab_nr + tab_name
+                                      -- can also be a function that returns value of max_length dynamically
+      mode = 0, -- 0: shows tab_nr
+                -- 1: shows tab_name
+                -- 2: shows tab_nr + tab_name
       tabs_color = {
         -- Same values like general color option can be used here.
         active = 'lualine_{section}_normal',   -- color for active tab

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ sections = {
       -- here, '|' refers to 'or', meaning a different acceptable format for that placeholder e.g.:
       -- 'highlight_group_name' | {fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style'}
       --
-      -- Note: all other color options including themes accept like diff_color same color values.
+      -- Note: all other color options like diff_color including themes accept same color values
       --
       -- example:
       --   color = {fg = '#ffaa88', bg = 'grey', gui='italic,bold'},
@@ -474,7 +474,6 @@ sections = {
     {
       'diff',
       colored = true, -- Displays diff status in color if set to true
-      -- All colors are in #rrggbb format
       diff_color = {
         -- Same values like general color option can be used here.
         added    = 'DiffAdd',    -- Changes the diff's added color


### PR DESCRIPTION
Happy new year, fellow lualine devs, contributors and users :partying_face: I've made an effort to (hopefully) improve the readability of lualine's documentation. Please note that the examples I have provided mostly ignore proper casing rules, which is a big deal. This MR does not make that mistake.

### The rules I made and followed along the way:

- Try (in most cases) to pad the inside of curly braces with a space, e.g.:
```lua
-- Previously:
sections = {lualine_c = {"os.date('%a')", 'data', "require'lsp-status'.status()"}}
-- Now:
sections = { lualine_c = { "os.date('%a')", 'data', "require'lsp-status'.status()" } }

-- Cases when not to:
sections = { lualine_a = {'FugitiveHead'} }
--                       ^^^^^^^^^^^^^^^^
```
- Always begin a line with "Note:" when going into detail for a specific option, where the details aren't necessarily important to know.
- Rely more and more on punctuation to make it easier to understand that
  two neighbouring comments are independent from each other.
- [1] Try and align comments as much as possible, and [2] implement an easier
to read format, e.g.:
```lua
   sections = {
      lualine_a = {
         'mode',
         icons_enabled = false, -- [1]: a comment.
         icon = nil,            -- [1]: another comment.
         
         separator = nil,       -- [1]:
                                -- an entire paragraph
                                -- that goes into detail
                                -- about the purpose of this option.
      }
   }

   -- [2]: 
   -- notice the empty line between the `icon` and `separator` option.
   -- that should hopefully make it easier to    
   -- differentiate one comment from another. 
   ```

- When providing an example, leave exactly two whitespaces, e.g.:
```lua
padding = 1, -- adds padding to the left and right of components.
             -- padding can be specified to left or right independently, e.g.:
             --   padding = { left = left_padding, right = right_padding }
```

- Make use of one single whitespace when dealing with bulletpoints, e.g.:
```lua
separator = nil, -- determines what separator to use for the component.
                 -- note:
                 --  when a string is provided it's treated as component_separator.
                 --  when a table is provided it's treated as section_separator.

      -- my proposition:

      -- bulletpoints usually begin with "-", at least when working with markdown.
      -- i personally think that using them within the context of a lua comment 
      -- can become too much of an effort to read. 
      -- here's an example:

      exhibit a:
      -- note:
      -- - lorem ipsum ipsum lorem, ipsum ipsum, lorem lorem.
      -- - lorem ipsum ipsum lorem, ipsum ipsum, lorem lorem.
   
      exhibit b:
      -- note:
      -- lorem ipsum ipsum lorem, ipsum ipsum, lorem lorem.
      -- lorem ipsum ipsum lorem, ipsum ipsum, lorem lorem.

      exhibit c:
      -- note:
      --  lorem ipsum ipsum lorem, ipsum ipsum, lorem lorem.
      --  lorem ipsum ipsum lorem, ipsum ipsum, lorem lorem.

      -- exhibit c is effortless to look at.
```

- Be a little more verbose, e.g.:
```lua
-- Previously:
   color = nil, -- the default is themes color for that section and mode
-- Now:
   color = nil, -- the default is your theme's color for that section and mode.
```
- Prefer "as such:" over "like:", e.g.:
```lua
-- Table of diagnostic sources, available sources are:
--   'nvim_lsp', 'nvim_diagnostic', 'coc', 'ale', 'vim_lsp'.
-- or a function that returns a table as such:
--   { error=error_cnt, warn=warn_cnt, info=info_cnt, hint=hint_cnt }
```