### PR TITLE
Schedule a redraw of tabline when setting tabline

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -258,6 +258,9 @@ local function set_tabline()
   if next(config.tabline) ~= nil then
     vim.go.tabline = "%{%v:lua.require'lualine'.tabline()%}"
     vim.go.showtabline = 2
+    vim.defer_fn(function()
+      vim.api.nvim_command('redrawtabline')
+    end, 0)
   end
 end
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -258,9 +258,9 @@ local function set_tabline()
   if next(config.tabline) ~= nil then
     vim.go.tabline = "%{%v:lua.require'lualine'.tabline()%}"
     vim.go.showtabline = 2
-    vim.defer_fn(function()
+    vim.schedule(function()
       vim.api.nvim_command('redrawtabline')
-    end, 0)
+    end)
   end
 end
 


### PR DESCRIPTION
The tabline isn't drawn until scrolling the window or opening another file. Opening multiple files at once (e.g. nvim a.txt b.txt) will only show the first.

By performing a deferred redraw of the tabline this fixes this startup behaviour problem.