### PR TITLE
fix: use nvim-api to avoid win_getid exceptions

### DIFF
--- a/lua/lualine/utils/notices.lua
+++ b/lua/lualine/utils/notices.lua
@@ -45,7 +45,7 @@ end
 function M.show_notices()
   vim.cmd('silent! keepalt split')
 
-  local winid = vim.fn.win_getid()
+  local winid = vim.api.nvim_get_current_win()
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_win_set_buf(winid, bufnr)
 

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -90,7 +90,7 @@ end
 
 -- Check if statusline is on focused window or not
 function M.is_focused()
-  return tonumber(vim.g.actual_curwin) == vim.fn.win_getid()
+  return tonumber(vim.g.actual_curwin) == vim.api.nvim_get_current_win()
 end
 
 --- Check what's the charecter at pos


### PR DESCRIPTION
Fixes an issue where an exception that is caused by `win_getid` can sometimes get triggered. Using the direct API call seems to fix that.
