### PR TITLE
refactor: use nvim api directly for bufnr

### DIFF
--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -35,7 +35,7 @@ end
 
 ---updates the current value of git_branch and sets up file watch on HEAD file
 local function update_branch()
-  active_bufnr = tostring(vim.fn.bufnr())
+  active_bufnr = tostring(vim.api.nvim_get_current_buf())
   file_changed:stop()
   local git_dir = current_git_dir
   if git_dir and #git_dir > 0 then
@@ -53,7 +53,7 @@ local function update_branch()
     -- set to '' when git dir was not found
     current_git_branch = ''
   end
-  branch_cache[vim.fn.bufnr()] = current_git_branch
+  branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
 end
 
 ---returns full path to git directory for dir_path or current directory

--- a/lua/lualine/components/branch/init.lua
+++ b/lua/lualine/components/branch/init.lua
@@ -14,7 +14,7 @@ M.init = function(self, options)
 end
 
 M.update_status = function(_, is_focused)
-  return git_branch.get_branch((not is_focused and vim.fn.bufnr()))
+  return git_branch.get_branch((not is_focused and vim.api.nvim_get_current_buf()))
 end
 
 return M

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -13,7 +13,7 @@ end
 
 ---setup icons, modified status for buffer
 function Buffer:get_props()
-  self.file = vim.fn.bufname(self.bufnr)
+  self.file = vim.api.nvim_buf_get_name(self.bufnr)
   self.buftype = vim.api.nvim_buf_get_option(self.bufnr, 'buftype')
   self.filetype = vim.api.nvim_buf_get_option(self.bufnr, 'filetype')
   local modified = self.options.show_modified_status and vim.api.nvim_buf_get_option(self.bufnr, 'modified')

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -66,11 +66,11 @@ function M:update_status()
   local data = {}
   local buffers = {}
   for b = 1, vim.fn.bufnr('$') do
-    if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
+    if vim.api.nvim_buf_get_option(b, 'buflisted') and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
       buffers[#buffers + 1] = Buffer({ bufnr = b, options = self.options, highlights = self.highlights })
     end
   end
-  local current_bufnr = vim.fn.bufnr()
+  local current_bufnr = vim.api.nvim_get_current_buf()
   local current = -2
   -- mark the first, last, current, before current, after current buffers
   -- for rendering
@@ -110,7 +110,7 @@ function M:update_status()
   -- start drawing from current buffer and draw left and right of it until
   -- all buffers are drawn or max_length has been reached.
   if current == -2 then
-    local b = Buffer({ bufnr = vim.fn.bufnr(), options = self.options, highlights = self.highlights })
+    local b = Buffer({ bufnr = vim.api.nvim_get_current_buf(), options = self.options, highlights = self.highlights })
     b.current = true
     if self.options.self.section < 'lualine_x' then
       b.last = true

--- a/lua/lualine/components/diagnostics/init.lua
+++ b/lua/lualine/components/diagnostics/init.lua
@@ -101,7 +101,7 @@ It needs to be updated to:
 end
 
 function M:update_status()
-  local bufnr = vim.fn.bufnr()
+  local bufnr = vim.api.nvim_get_current_buf()
   local diagnostics_count
   local result = {}
   if self.options.update_in_insert or vim.api.nvim_get_mode().mode:sub(1, 1) ~= 'i' then

--- a/lua/lualine/components/diagnostics/sources.lua
+++ b/lua/lualine/components/diagnostics/sources.lua
@@ -31,7 +31,7 @@ M.sources = {
     end
   end,
   ale = function()
-    local ok, data = pcall(vim.fn['ale#statusline#Count'], vim.fn.bufnr())
+    local ok, data = pcall(vim.fn['ale#statusline#Count'], vim.api.nvim_get_current_buf())
     if ok then
       return data.error + data.style_error, data.warning + data.style_warning, data.info, 0
     else

--- a/lua/lualine/components/diff/git_diff.lua
+++ b/lua/lualine/components/diff/git_diff.lua
@@ -44,7 +44,7 @@ function M.get_sign_count(bufnr)
   end
   if M.src then
     git_diff = M.src()
-    diff_cache[vim.fn.bufnr()] = git_diff
+    diff_cache[vim.api.nvim_get_current_buf()] = git_diff
   elseif vim.g.actual_curbuf ~= nil and active_bufnr ~= vim.g.actual_curbuf then
     -- Workaround for https://github.com/nvim-lualine/lualine.nvim/issues/286
     -- See upstream issue https://github.com/neovim/neovim/issues/15300
@@ -85,7 +85,7 @@ end
 ---updates the job args
 function M.update_diff_args()
   -- Donn't show git diff when current buffer doesn't have a filename
-  active_bufnr = tostring(vim.fn.bufnr())
+  active_bufnr = tostring(vim.api.nvim_get_current_buf())
   if #vim.fn.expand('%') == 0 then
     M.diff_args = nil
     git_diff = nil
@@ -115,7 +115,7 @@ function M.update_diff_args()
       else
         git_diff = { added = 0, modified = 0, removed = 0 }
       end
-      diff_cache[vim.fn.bufnr()] = git_diff
+      diff_cache[vim.api.nvim_get_current_buf()] = git_diff
     end,
   }
   M.update_git_diff()

--- a/lua/lualine/components/diff/init.lua
+++ b/lua/lualine/components/diff/init.lua
@@ -66,7 +66,7 @@ end
 
 -- Function that runs everytime statusline is updated
 function M:update_status(is_focused)
-  local git_diff = modules.git_diff.get_sign_count((not is_focused and vim.fn.bufnr()))
+  local git_diff = modules.git_diff.get_sign_count((not is_focused and vim.api.nvim_get_current_buf()))
   if git_diff == nil then
     return ''
   end

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -17,7 +17,7 @@ function Tab:label()
   local buflist = vim.fn.tabpagebuflist(self.tabnr)
   local winnr = vim.fn.tabpagewinnr(self.tabnr)
   local bufnr = buflist[winnr]
-  local file = vim.fn.bufname(bufnr)
+  local file = vim.api.nvim_buf_get_name(bufnr)
   local buftype = vim.fn.getbufvar(bufnr, '&buftype')
   if buftype == 'help' then
     return 'help:' .. vim.fn.fnamemodify(file, ':t:r')


### PR DESCRIPTION
Remove some overhead by using `vim.api` directly
