### PR TITLE
feat: dynamic color

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 	@rm -rf tmp_home
 
 docgen:
-	@bash ./scripts/docgen.sh
+	@sh ./scripts/docgen.sh
 
 precommit_check: docgen format test lint
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ sections = {
       --   color = { fg = '#ffaa88', bg = 'grey', gui='italic,bold' },
       --   color = { fg = 204 }   -- When fg/bg are omitted, they default to the your theme's fg/bg.
       --   color = 'WarningMsg'   -- Highlight groups can also be used.
-      --   color = function(mode, section)
+      --   color = function(section)
       --      return { fg = vim.fn.mode() == 'n' and '#ffaa88' or '#33aaff',
       --               bg = 'grey', gui='italic,bold' }
       --      end,

--- a/README.md
+++ b/README.md
@@ -377,17 +377,16 @@ sections = {
       -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' } | function
       -- Note:
       --  '|' is synonymous with 'or', meaning a different acceptable format for that placeholder.
-      -- function has to return 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
+      -- color function has to return one of other color types ('highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' })
+      -- color functions can be used to have different colors based on state as shown below.
       --
       -- Examples:
       --   color = { fg = '#ffaa88', bg = 'grey', gui='italic,bold' },
       --   color = { fg = 204 }   -- When fg/bg are omitted, they default to the your theme's fg/bg.
       --   color = 'WarningMsg'   -- Highlight groups can also be used.
       --   color = function(section)
-      --      return { fg = vim.fn.mode() == 'n' and '#ffaa88' or '#33aaff',
-      --               bg = 'grey', gui='italic,bold' }
-      --      end,
-      --
+      --      return { fg = vim.bo.modified and '#aa3355' or '#33aa88' }
+      --   end,
       color = nil, -- The default is your theme's color for that section and mode.
 
       -- Specify what type a component is, if omitted, lualine will guess it for you.

--- a/README.md
+++ b/README.md
@@ -374,14 +374,19 @@ sections = {
 
       -- Defines a custom color for the component:
       --
-      -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
+      -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' } | function
       -- Note:
       --  '|' is synonymous with 'or', meaning a different acceptable format for that placeholder.
+      -- function has to return 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
       --
       -- Examples:
       --   color = { fg = '#ffaa88', bg = 'grey', gui='italic,bold' },
       --   color = { fg = 204 }   -- When fg/bg are omitted, they default to the your theme's fg/bg.
       --   color = 'WarningMsg'   -- Highlight groups can also be used.
+      --   color = function(mode, section)
+      --      return { fg = vim.fn.mode() == 'n' and '#ffaa88' or '#33aaff',
+      --               bg = 'grey', gui='italic,bold' }
+      --      end,
       --
       color = nil, -- The default is your theme's color for that section and mode.
 

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -387,14 +387,19 @@ General component options              These are options that control behavior
     
           -- Defines a custom color for the component:
           --
-          -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
+          -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' } | function
           -- Note:
           --  '|' is synonymous with 'or', meaning a different acceptable format for that placeholder.
+          -- function has to return 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
           --
           -- Examples:
           --   color = { fg = '#ffaa88', bg = 'grey', gui='italic,bold' },
           --   color = { fg = 204 }   -- When fg/bg are omitted, they default to the your theme's fg/bg.
           --   color = 'WarningMsg'   -- Highlight groups can also be used.
+          --   color = function(mode, section)
+          --      return { fg = vim.fn.mode() == 'n' and '#ffaa88' or '#33aaff',
+          --               bg = 'grey', gui='italic,bold' }
+          --      end,
           --
           color = nil, -- The default is your theme's color for that section and mode.
     

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -396,7 +396,7 @@ General component options              These are options that control behavior
           --   color = { fg = '#ffaa88', bg = 'grey', gui='italic,bold' },
           --   color = { fg = 204 }   -- When fg/bg are omitted, they default to the your theme's fg/bg.
           --   color = 'WarningMsg'   -- Highlight groups can also be used.
-          --   color = function(mode, section)
+          --   color = function(section)
           --      return { fg = vim.fn.mode() == 'n' and '#ffaa88' or '#33aaff',
           --               bg = 'grey', gui='italic,bold' }
           --      end,

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -390,17 +390,16 @@ General component options              These are options that control behavior
           -- 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' } | function
           -- Note:
           --  '|' is synonymous with 'or', meaning a different acceptable format for that placeholder.
-          -- function has to return 'highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' }
+          -- color function has to return one of other color types ('highlight_group_name' | { fg = '#rrggbb'|cterm_value(0-255)|'color_name(red)', bg= '#rrggbb', gui='style' })
+          -- color functions can be used to have different colors based on state as shown below.
           --
           -- Examples:
           --   color = { fg = '#ffaa88', bg = 'grey', gui='italic,bold' },
           --   color = { fg = 204 }   -- When fg/bg are omitted, they default to the your theme's fg/bg.
           --   color = 'WarningMsg'   -- Highlight groups can also be used.
           --   color = function(section)
-          --      return { fg = vim.fn.mode() == 'n' and '#ffaa88' or '#33aaff',
-          --               bg = 'grey', gui='italic,bold' }
-          --      end,
-          --
+          --      return { fg = vim.bo.modified and '#aa3355' or '#33aa88' }
+          --   end,
           color = nil, -- The default is your theme's color for that section and mode.
     
           -- Specify what type a component is, if omitted, lualine will guess it for you.

--- a/examples/evil_lualine.lua
+++ b/examples/evil_lualine.lua
@@ -89,6 +89,9 @@ ins_left {
 ins_left {
   -- mode component
   function()
+    return ''
+  end,
+  color = function()
     -- auto change color according to neovims mode
     local mode_color = {
       n = colors.red,
@@ -112,10 +115,8 @@ ins_left {
       ['!'] = colors.red,
       t = colors.red,
     }
-    vim.api.nvim_command('hi! LualineMode guifg=' .. mode_color[vim.fn.mode()] .. ' guibg=' .. colors.bg)
-    return ''
+    return { fg = mode_color[vim.fn.mode()] }
   end,
-  color = 'LualineMode',
   padding = { right = 1 },
 }
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -158,7 +158,7 @@ local statusline = modules.utils.retry_call_wrap(function(sections, is_focused)
       if #section_data > 0 then
         if not applied_midsection_divider and section_name > 'c' then
           applied_midsection_divider = true
-          section_data = modules.highlight.format_highlight('lualine_c') .. '%=' .. section_data
+          section_data = modules.highlight.format_highlight('c', is_focused) .. '%=' .. section_data
         end
         if not applied_trunc and section_name > 'b' then
           applied_trunc = true
@@ -170,7 +170,7 @@ local statusline = modules.utils.retry_call_wrap(function(sections, is_focused)
   end
   if applied_midsection_divider == false and config.options.always_divide_middle ~= false then
     -- When non of section x,y,z is present
-    table.insert(status, modules.highlight.format_highlight('lualine_c') .. '%=')
+    table.insert(status, modules.highlight.format_highlight('c', is_focused) .. '%=')
   end
   return apply_transitional_separators(table.concat(status))
 end)

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -54,7 +54,8 @@ function M:create_option_highlights()
     self.options.color_highlight = highlight.create_component_highlight_group(
       self.options.color,
       self.options.component_name,
-      self.options
+      self.options,
+      false
     )
   end
 end

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -38,7 +38,7 @@ end
 function M:set_separator()
   if self.options.separator == nil then
     if self.options.component_separators then
-      if self.options.self.section < 'lualine_x' then
+      if self.options.self.section < 'x' then
         self.options.separator = self.options.component_separators.left
       else
         self.options.separator = self.options.component_separators.right
@@ -119,7 +119,7 @@ function M:apply_separator()
   local separator = self.options.separator
   if type(separator) == 'table' then
     if self.options.separator[2] == '' then
-      if self.options.self.section < 'lualine_x' then
+      if self.options.self.section < 'x' then
         separator = self.options.component_separators.left
       else
         separator = self.options.component_separators.right

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -159,6 +159,16 @@ function M:strip_separator()
   return self.status
 end
 
+function M:get_default_hl()
+  if self.options.color_highlight then
+    return highlight.component_format_highlight(self.options.color_highlight)
+  elseif self.default_hl then
+     return self.default_hl
+  else
+    return highlight.format_highlight(self.options.self.section)
+  end
+end
+
 -- luacheck: push no unused args
 ---actual function that updates a component. Must be overwritten with component functionality
 function M:update_status(is_focused) end
@@ -172,6 +182,7 @@ function M:draw(default_highlight, is_focused)
   if self.options.cond ~= nil and self.options.cond() ~= true then
     return self.status
   end
+  self.default_hl = default_highlight
   local status = self:update_status(is_focused)
   if self.options.fmt then
     status = self.options.fmt(status or '')

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -163,7 +163,7 @@ function M:get_default_hl()
   if self.options.color_highlight then
     return highlight.component_format_highlight(self.options.color_highlight)
   elseif self.default_hl then
-     return self.default_hl
+    return self.default_hl
   else
     return highlight.format_highlight(self.options.self.section)
   end

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -89,7 +89,9 @@ end
 ---applies custom highlights for component
 function M:apply_highlights(default_highlight)
   if self.options.color_highlight then
-    self.status = highlight.component_format_highlight(self.options.color_highlight) .. self.status
+    local hl_fmt
+    hl_fmt, M.color_fn_cache = highlight.component_format_highlight(self.options.color_highlight)
+    self.status = hl_fmt .. self.status
   end
   if type(self.options.separator) ~= 'table' and self.status:find('%%#') then
     -- Apply default highlight only when we aren't applying trans sep and

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -77,11 +77,11 @@ function Buffer:render()
     .. line
 
   -- apply separators
-  if self.options.self.section < 'lualine_x' and not self.first then
+  if self.options.self.section < 'x' and not self.first then
     local sep_before = self:separator_before()
     line = sep_before .. line
     self.len = self.len + vim.fn.strchars(sep_before)
-  elseif self.options.self.section >= 'lualine_x' and not self.last then
+  elseif self.options.self.section >= 'x' and not self.last then
     local sep_after = self:separator_after()
     line = line .. sep_after
     self.len = self.len + vim.fn.strchars(sep_after)

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -44,8 +44,8 @@ end
 function M:init(options)
   M.super.init(self, options)
   default_options.buffers_color = {
-    active = get_hl(options.self.section, true),
-    inactive = get_hl(options.self.section, false),
+    active = get_hl('lualine_'..options.self.section, true),
+    inactive = get_hl('lualine_'..options.self.section, false),
   }
   self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
   self.highlights = {
@@ -112,7 +112,7 @@ function M:update_status()
   if current == -2 then
     local b = Buffer { bufnr = vim.api.nvim_get_current_buf(), options = self.options, highlights = self.highlights }
     b.current = true
-    if self.options.self.section < 'lualine_x' then
+    if self.options.self.section < 'x' then
       b.last = true
       if #buffers > 0 then
         buffers[#buffers].last = nil

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -57,7 +57,7 @@ function M:init(options)
     ),
     inactive = highlight.create_component_highlight_group(
       self.options.buffers_color.inactive,
-      'buffers_active',
+      'buffers_inactive',
       self.options,
       false
     ),

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -52,12 +52,14 @@ function M:init(options)
     active = highlight.create_component_highlight_group(
       self.options.buffers_color.active,
       'buffers_active',
-      self.options
+      self.options,
+      false
     ),
     inactive = highlight.create_component_highlight_group(
       self.options.buffers_color.inactive,
       'buffers_active',
-      self.options
+      self.options,
+      false
     ),
   }
 end

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -44,8 +44,8 @@ end
 function M:init(options)
   M.super.init(self, options)
   default_options.buffers_color = {
-    active = get_hl('lualine_'..options.self.section, true),
-    inactive = get_hl('lualine_'..options.self.section, false),
+    active = get_hl('lualine_' .. options.self.section, true),
+    inactive = get_hl('lualine_' .. options.self.section, false),
   }
   self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
   self.highlights = {

--- a/lua/lualine/components/diagnostics/init.lua
+++ b/lua/lualine/components/diagnostics/init.lua
@@ -20,6 +20,10 @@ function M:init(options)
   M.super.init(self, options)
   -- Apply default options
   self.options = vim.tbl_deep_extend('keep', self.options or {}, modules.default_config.options)
+  -- apply default sources
+  if not self.options.sources then
+    self.options.sources = { vim.fn.has('nvim-0.6') == 1 and 'nvim_diagnostic' or 'nvim_lsp', 'coc' }
+  end
   -- Apply default symbols
   self.symbols = vim.tbl_extend(
     'keep',

--- a/lua/lualine/components/diagnostics/init.lua
+++ b/lua/lualine/components/diagnostics/init.lua
@@ -20,10 +20,6 @@ function M:init(options)
   M.super.init(self, options)
   -- Apply default options
   self.options = vim.tbl_deep_extend('keep', self.options or {}, modules.default_config.options)
-  -- apply default sources
-  if not self.options.sources then
-    self.options.sources = { vim.fn.has('nvim-0.6') == 1 and 'nvim_diagnostic' or 'nvim_lsp', 'coc' }
-  end
   -- Apply default symbols
   self.symbols = vim.tbl_extend(
     'keep',

--- a/lua/lualine/components/diagnostics/init.lua
+++ b/lua/lualine/components/diagnostics/init.lua
@@ -33,22 +33,26 @@ function M:init(options)
       error = modules.highlight.create_component_highlight_group(
         self.options.diagnostics_color.error,
         'diagnostics_error',
-        self.options
+        self.options,
+        false
       ),
       warn = modules.highlight.create_component_highlight_group(
         self.options.diagnostics_color.warn,
         'diagnostics_warn',
-        self.options
+        self.options,
+        false
       ),
       info = modules.highlight.create_component_highlight_group(
         self.options.diagnostics_color.info,
         'diagnostics_info',
-        self.options
+        self.options,
+        false
       ),
       hint = modules.highlight.create_component_highlight_group(
         self.options.diagnostics_color.hint,
         'diagnostics_hint',
-        self.options
+        self.options,
+        false
       ),
     }
   end

--- a/lua/lualine/components/diff/init.lua
+++ b/lua/lualine/components/diff/init.lua
@@ -47,17 +47,20 @@ function M:init(options)
       added = modules.highlight.create_component_highlight_group(
         self.options.diff_color.added,
         'diff_added',
-        self.options
+        self.options,
+        false
       ),
       modified = modules.highlight.create_component_highlight_group(
         self.options.diff_color.modified,
         'diff_modified',
-        self.options
+        self.options,
+        false
       ),
       removed = modules.highlight.create_component_highlight_group(
         self.options.diff_color.removed,
         'diff_removed',
-        self.options
+        self.options,
+        false
       ),
     }
   end

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -43,7 +43,8 @@ function M:apply_icon()
         icon_highlight = modules.highlight.create_component_highlight_group(
           { fg = highlight_color },
           icon_highlight_group,
-          self.options
+          self.options,
+          false
         )
         icon_hl_cache[highlight_color] = icon_highlight
       end

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -37,7 +37,7 @@ function M:apply_icon()
 
     if icon and self.options.colored then
       local highlight_color = modules.utils.extract_highlight_colors(icon_highlight_group, 'fg')
-      local default_highlight = modules.highlight.format_highlight(self.options.self.section)
+      local default_highlight = self:get_default_hl()
       local icon_highlight = icon_hl_cache[highlight_color]
       if not icon_highlight or not modules.highlight.highlight_exists(icon_highlight.name .. '_normal') then
         icon_highlight = modules.highlight.create_component_highlight_group(

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -37,7 +37,7 @@ function M:apply_icon()
 
     if icon and self.options.colored then
       local highlight_color = modules.utils.extract_highlight_colors(icon_highlight_group, 'fg')
-      local default_highlight = modules.highlight.format_highlight(self.options.self.section)
+      local default_highlight = modules.highlight.format_highlight(self.options.self.section:match('lualine_(.*)'))
       local icon_highlight = icon_hl_cache[highlight_color]
       if not icon_highlight or not modules.highlight.highlight_exists(icon_highlight.name .. '_normal') then
         icon_highlight = modules.highlight.create_component_highlight_group(

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -37,7 +37,7 @@ function M:apply_icon()
 
     if icon and self.options.colored then
       local highlight_color = modules.utils.extract_highlight_colors(icon_highlight_group, 'fg')
-      local default_highlight = modules.highlight.format_highlight(self.options.self.section:match('lualine_(.*)'))
+      local default_highlight = modules.highlight.format_highlight(self.options.self.section)
       local icon_highlight = icon_hl_cache[highlight_color]
       if not icon_highlight or not modules.highlight.highlight_exists(icon_highlight.name .. '_normal') then
         icon_highlight = modules.highlight.create_component_highlight_group(

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -22,6 +22,7 @@ function M.update_status()
   return modules.utils.stl_escape(ft)
 end
 
+local icon_hl_cache = {}
 function M:apply_icon()
   if not self.options.icons_enabled then
     return
@@ -37,13 +38,14 @@ function M:apply_icon()
     if icon and self.options.colored then
       local highlight_color = modules.utils.extract_highlight_colors(icon_highlight_group, 'fg')
       local default_highlight = modules.highlight.format_highlight(self.options.self.section)
-      local icon_highlight = self.options.self.section .. '_' .. icon_highlight_group
-      if not modules.highlight.highlight_exists(icon_highlight .. '_normal') then
+      local icon_highlight = icon_hl_cache[highlight_color]
+      if not icon_highlight or not modules.highlight.highlight_exists(icon_highlight.name .. '_normal') then
         icon_highlight = modules.highlight.create_component_highlight_group(
           { fg = highlight_color },
           icon_highlight_group,
           self.options
         )
+        icon_hl_cache[highlight_color] = icon_highlight
       end
 
       icon = modules.highlight.component_format_highlight(icon_highlight) .. icon .. default_highlight

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -35,8 +35,8 @@ end
 function M:init(options)
   M.super.init(self, options)
   default_options.tabs_color = {
-    active = get_hl('lualine_'..options.self.section, true),
-    inactive = get_hl('lualine_'..options.self.section, false),
+    active = get_hl('lualine_' .. options.self.section, true),
+    inactive = get_hl('lualine_' .. options.self.section, false),
   }
   self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
   -- stylua: ignore

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -44,12 +44,14 @@ function M:init(options)
     active = highlight.create_component_highlight_group(
       self.options.tabs_color.active,
       'tabs_active',
-      self.options
+      self.options,
+      false
     ),
     inactive = highlight.create_component_highlight_group(
       self.options.tabs_color.inactive,
       'tabs_active',
-      self.options
+      self.options,
+      false
     ),
   }
 end

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -49,7 +49,7 @@ function M:init(options)
     ),
     inactive = highlight.create_component_highlight_group(
       self.options.tabs_color.inactive,
-      'tabs_active',
+      'tabs_inactive',
       self.options,
       false
     ),

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -35,8 +35,8 @@ end
 function M:init(options)
   M.super.init(self, options)
   default_options.tabs_color = {
-    active = get_hl(options.self.section, true),
-    inactive = get_hl(options.self.section, false),
+    active = get_hl('lualine_'..options.self.section, true),
+    inactive = get_hl('lualine_'..options.self.section, false),
   }
   self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
   -- stylua: ignore

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -70,11 +70,11 @@ function Tab:render()
     .. line
 
   -- apply separators
-  if self.options.self.section < 'lualine_x' and not self.first then
+  if self.options.self.section < 'x' and not self.first then
     local sep_before = self:separator_before()
     line = sep_before .. line
     self.len = self.len + vim.fn.strchars(sep_before)
-  elseif self.options.self.section >= 'lualine_x' and not self.last then
+  elseif self.options.self.section >= 'x' and not self.last then
     local sep_after = self:separator_after()
     line = line .. sep_after
     self.len = self.len + vim.fn.strchars(sep_after)

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -155,13 +155,13 @@ function M.create_highlight_groups(theme)
   clear_highlights()
   active_theme = theme
   theme_hls = {}
-  local psudo_options = {self={section='lualine_a'}}
+  local psudo_options = { self = { section = 'lualine_a' } }
   create_cterm_colors = not vim.go.termguicolors
   for mode, sections in pairs(theme) do
     theme_hls[mode] = {}
     for section, color in pairs(sections) do
-      local hl_tag = table.concat({section, mode}, '_')
-      psudo_options.self.section = 'lualine_'..section
+      local hl_tag = table.concat({ section, mode }, '_')
+      psudo_options.self.section = 'lualine_' .. section
       theme_hls[mode][section] = M.create_component_highlight_group(color, hl_tag, psudo_options, true)
     end
   end
@@ -257,7 +257,7 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
   if type(color) == 'string' then
     local highlight_group_name = table.concat({ 'lualine', highlight_tag }, '_')
     M.highlight(highlight_group_name, nil, nil, nil, color) -- l8nk to group
-    return { name = highlight_group_name, no_mode = true, link=true, no_default = apply_no_default }
+    return { name = highlight_group_name, no_mode = true, link = true, no_default = apply_no_default }
   end
   if type(color) == 'function' then
     local highlight_group_name = table.concat({ 'lualine', highlight_tag }, '_')
@@ -275,7 +275,7 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
     -- each mode as they will surely look the same. So we can work without options
     local highlight_group_name = table.concat({ 'lualine', highlight_tag }, '_')
     M.highlight(highlight_group_name, color.fg, color.bg, color.gui, nil)
-    return { name = highlight_group_name, no_mode = true, section = section, no_default = apply_no_default, }
+    return { name = highlight_group_name, no_mode = true, section = section, no_default = apply_no_default }
   end
 
   local modes = {
@@ -355,7 +355,7 @@ function M.format_highlight(section, is_focused)
   elseif theme_hls['normal'] and section > 'c' and theme_hls['normal'][section_highlight_map[section]] then
     return M.component_format_highlight(theme_hls['normal'][section_highlight_map[section]], is_focused)
   else
-    error("Unable to ditermine color for mode: "..mode..", section: ".. section)
+    error('Unable to ditermine color for mode: ' .. mode .. ', section: ' .. section)
   end
   -- local highlight_name = M.append_mode(section, is_focused)
   -- if section > 'lualine_c' and not M.highlight_exists(highlight_name) then

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -193,8 +193,7 @@ local function get_default_component_color(hl_name, mode, section, color, option
   if ret.fg and ret.bg then
     return ret
   end
-  if options.color and options.color_highlight
-    and  options.color_highlight.name ~= hl_name then
+  if options.color and options.color_highlight and options.color_highlight.name ~= hl_name then
     if type(options.color) == 'string' then
       options.color = modules.utils.extract_highlight_colors(options.color)
     elseif type(options.color) == 'function' then
@@ -271,13 +270,19 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
   if type(color) == 'string' then
     local highlight_group_name = table.concat({ 'lualine', highlight_tag }, '_')
     M.highlight(highlight_group_name, nil, nil, nil, color) -- l8nk to group
-    return { name = highlight_group_name, no_mode = true, link = true, no_default = apply_no_default, options = options}
+    return {
+      name = highlight_group_name,
+      no_mode = true,
+      link = true,
+      no_default = apply_no_default,
+      options = options,
+    }
   end
   if type(color) == 'function' then
     local highlight_group_name = table.concat({ 'lualine', highlight_tag }, '_')
     -- create a dummy hl entry so now other hls can attach to it.
     loaded_highlights[highlight_group_name] = {
-      attached =  {},
+      attached = {},
     }
     return {
       name = highlight_group_name,

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -167,13 +167,13 @@ function M.create_highlight_groups(theme)
   clear_highlights()
   active_theme = theme
   theme_hls = {}
-  local psudo_options = { self = { section = 'lualine_a' } }
+  local psudo_options = { self = { section = 'a' } }
   create_cterm_colors = not vim.go.termguicolors
   for mode, sections in pairs(theme) do
     theme_hls[mode] = {}
     for section, color in pairs(sections) do
       local hl_tag = table.concat({ section, mode }, '_')
-      psudo_options.self.section = 'lualine_' .. section
+      psudo_options.self.section = section
       theme_hls[mode][section] = M.create_component_highlight_group(color, hl_tag, psudo_options, true)
     end
   end
@@ -248,8 +248,7 @@ end
 ---@return table that can be used by component_format_highlight
 ---  to retrieve highlight group
 function M.create_component_highlight_group(color, highlight_tag, options, apply_no_default)
-  -- convert lualine_a -> a before setting section
-  local section = options.self.section:match('lualine_(.*)')
+  local section = options.self.section
   if section > 'c' and not active_theme.normal[section] then
     section = section_highlight_map[section]
   end
@@ -257,10 +256,7 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
   local tag_id = 0
   while
     M.highlight_exists(table.concat({ 'lualine', highlight_tag }, '_'))
-    or (
-      options.self.section
-      and M.highlight_exists(table.concat({ options.self.section, highlight_tag, 'normal' }, '_'))
-    )
+    or (section and M.highlight_exists(table.concat({ 'lualine', section, highlight_tag, 'normal' }, '_')))
   do
     highlight_tag = highlight_tag .. '_' .. tostring(tag_id)
     tag_id = tag_id + 1
@@ -322,12 +318,12 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
     'inactive',
   }
   for _, mode in ipairs(modes) do
-    local highlight_group_name = table.concat({ options.self.section, highlight_tag, mode }, '_')
+    local highlight_group_name = table.concat({ 'lualine', section, highlight_tag, mode }, '_')
     local cl = get_default_component_color(highlight_group_name, mode, section, color, options)
     M.highlight(highlight_group_name, cl.fg, cl.bg, color.gui, nil)
   end
   return {
-    name = options.self.section .. '_' .. highlight_tag,
+    name = table.concat({ 'lualine', section, highlight_tag }, '_'),
     fn = nil,
     no_mode = false,
     link = false,

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -379,7 +379,7 @@ function M.format_highlight(section, is_focused)
   elseif theme_hls['normal'] and section > 'c' and theme_hls['normal'][section_highlight_map[section]] then
     return M.component_format_highlight(theme_hls['normal'][section_highlight_map[section]], is_focused)
   else
-    error('Unable to determine color for mode: ' .. mode .. ', section: ' .. section)
+    return '%#' .. M.append_mode('lualine_' .. section) .. '#'
   end
 end
 

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -374,7 +374,7 @@ function M.format_highlight(section, is_focused)
   elseif theme_hls['normal'] and section > 'c' and theme_hls['normal'][section_highlight_map[section]] then
     return M.component_format_highlight(theme_hls['normal'][section_highlight_map[section]], is_focused)
   else
-    error('Unable to ditermine color for mode: ' .. mode .. ', section: ' .. section)
+    error('Unable to determine color for mode: ' .. mode .. ', section: ' .. section)
   end
 end
 

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -200,7 +200,16 @@ end
 ---@param color table color passed for creating component highlight
 ---@param options table Options table of component this is first fall back
 local function get_default_component_color(hl_name, mode, section, color, options)
-  local default_theme_color = active_theme[mode] and active_theme[mode][section] or active_theme.normal[section]
+  local default_theme_color
+  if active_theme[mode] and active_theme[mode][section] then
+    default_theme_color = active_theme[mode][section]
+  elseif section >= 'c' and active_theme[mode] and active_theme[mode][section_highlight_map[section]] then
+    default_theme_color = active_theme[mode][section_highlight_map[section]]
+  elseif section >= 'c' and active_theme.normal[section_highlight_map[section]] then
+    default_theme_color = active_theme.normal[section_highlight_map[section]]
+  else
+    default_theme_color = active_theme.normal[section]
+  end
   local ret = { fg = color.fg, bg = color.bg }
   if ret.fg and ret.bg then
     return ret

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -384,7 +384,7 @@ function M.component_format_highlight(highlight, is_focused)
         color = get_default_component_color(hl, append_mode(''):sub(2), highlight.section, color, highlight.options)
       end
       M.highlight(hl_name, color.fg, color.bg, color.gui, nil)
-      return '%#' .. hl_name .. '#'
+      return '%#' .. hl_name .. '#', color
     end
   end
 end

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -226,7 +226,7 @@ local function get_default_component_color(highlight, mode, section, color, opti
       if def_color == highlight.fn then
         return
       end
-      def_color = def_color(mode, section)
+      def_color = def_color{section = section}
     end
     if type(def_color) == 'table' then
       if not ret.fg and def_color.fg then
@@ -371,8 +371,7 @@ function M.component_format_highlight(highlight, is_focused)
     highlight_group = append_mode(highlight_group, is_focused)
     return '%#' .. highlight_group .. '#'
   else
-    local mode = require('lualine.utils.mode').get_mode()
-    local color = highlight.fn { mode = mode, section = highlight.section } or {}
+    local color = highlight.fn { section = highlight.section } or {}
     local hl_name = highlight.name
     if type(color) == 'string' then
       M.highlight(hl_name, nil, nil, nil, color)

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -376,7 +376,7 @@ end
 ---@return string formatted highlight group name
 function M.format_highlight(section, is_focused)
   local mode = append_mode('', is_focused):sub(2)
-  local ret
+  local ret = ''
 
   if theme_hls[mode] and theme_hls[mode][section] then
     ret = M.component_format_highlight(theme_hls[mode][section], is_focused)
@@ -386,8 +386,6 @@ function M.format_highlight(section, is_focused)
     ret = M.component_format_highlight(theme_hls['normal'][section], is_focused)
   elseif theme_hls['normal'] and section > 'c' and theme_hls['normal'][section_highlight_map[section]] then
     ret = M.component_format_highlight(theme_hls['normal'][section_highlight_map[section]], is_focused)
-  else
-    ret = string.format('%%#lualine_%s_%s#', section, mode)
   end
 
   return ret

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -112,6 +112,14 @@ function M.highlight(name, foreground, background, gui, link)
   -- update attached hl groups
   local old_hl_def = loaded_highlights[name]
   if old_hl_def and next(old_hl_def.attached) then
+    -- Update attached hl groups as they announced to depend on hl_group 'name'
+    -- 'hl' being in 'name'a attached table means 'hl'
+    -- depends of 'name'.
+    -- 'hl' key in attached table will contain a table that
+    -- defines the reletaion between 'hl' & 'name'.
+    -- name.attached.hl = { bg = 'fg' } means
+    -- hl's fg is same as 'names' bg . So 'hl's fg should
+    -- be updated when ever 'name' changes it's 'bg'
     local bg_changed = old_hl_def.bg ~= background
     local fg_changed = old_hl_def.bg ~= foreground
     local gui_changed = old_hl_def.gui ~= gui
@@ -273,17 +281,21 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
     highlight_tag = highlight_tag .. '_' .. tostring(tag_id)
     tag_id = tag_id + 1
   end
+
   if type(color) == 'string' then
     local highlight_group_name = table.concat({ 'lualine', highlight_tag }, '_')
     M.highlight(highlight_group_name, nil, nil, nil, color) -- l8nk to group
     return {
       name = highlight_group_name,
+      fn = nil,
       no_mode = true,
       link = true,
-      no_default = apply_no_default,
+      section = section,
       options = options,
+      no_default = apply_no_default,
     }
   end
+
   if type(color) == 'function' then
     local highlight_group_name = table.concat({ 'lualine', highlight_tag }, '_')
     -- create a dummy hl entry so now other hls can attach to it.
@@ -294,11 +306,13 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
       name = highlight_group_name,
       fn = color,
       no_mode = false,
+      link = false,
       section = section,
       options = options,
       no_default = apply_no_default,
     }
   end
+
   if apply_no_default or (color.bg and color.fg) then
     -- When bg and fg are both present we donn't need to set highlighs for
     -- each mode as they will surely look the same. So we can work without options
@@ -323,7 +337,9 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
   end
   return {
     name = options.self.section .. '_' .. highlight_tag,
+    fn = nil,
     no_mode = false,
+    link = false,
     section = section,
     options = options,
     no_default = apply_no_default,

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -339,7 +339,7 @@ function M.component_format_highlight(highlight, is_focused)
     return '%#' .. highlight_group .. '#'
   else
     local mode = require('lualine.utils.mode').get_mode()
-    local color = highlight.fn { mode = mode, section = highlight.section }
+    local color = highlight.fn { mode = mode, section = highlight.section } or {}
     if type(color) == 'string' then
       local hl_name = highlight.name
       M.highlight(hl_name, nil, nil, nil, color)

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -199,7 +199,8 @@ end
 ---@param section string the lualine section component is in.
 ---@param color table color passed for creating component highlight
 ---@param options table Options table of component this is first fall back
-local function get_default_component_color(hl_name, mode, section, color, options)
+local function get_default_component_color(highlight, mode, section, color, options)
+  local hl_name = highlight.name
   local default_theme_color
   if active_theme[mode] and active_theme[mode][section] then
     default_theme_color = active_theme[mode][section]
@@ -210,15 +211,21 @@ local function get_default_component_color(hl_name, mode, section, color, option
   else
     default_theme_color = active_theme.normal[section]
   end
-  local ret = { fg = color.fg, bg = color.bg }
+  local ret = { fg = color.fg, bg = color.bg, gui = color.gui }
   if ret.fg and ret.bg then
     return ret
   end
 
   local function apply_default(def_color, def_name)
+    if vim.deep_equal(def_color, color) then
+      return
+    end
     if type(def_color) == 'string' then
       def_color = modules.utils.extract_highlight_colors(def_color)
     elseif type(def_color) == 'function' then
+      if def_color == highlight.fn then
+        return
+      end
       def_color = def_color(mode, section)
     end
     if type(def_color) == 'table' then
@@ -327,9 +334,17 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
     'inactive',
   }
   for _, mode in ipairs(modes) do
-    local highlight_group_name = table.concat({ 'lualine', section, highlight_tag, mode }, '_')
-    local cl = get_default_component_color(highlight_group_name, mode, section, color, options)
-    M.highlight(highlight_group_name, cl.fg, cl.bg, color.gui, nil)
+    local hl = {
+      name = table.concat({ 'lualine', section, highlight_tag, mode }, '_'),
+      fn = nil,
+      no_mode = false,
+      link = false,
+      section = section,
+      options = options,
+      no_default = apply_no_default,
+    }
+    local cl = get_default_component_color(hl, mode, section, color, options)
+    M.highlight(hl.name, cl.fg, cl.bg, color.gui, nil)
   end
   return {
     name = table.concat({ 'lualine', section, highlight_tag }, '_'),
@@ -364,8 +379,9 @@ function M.component_format_highlight(highlight, is_focused)
       return '%#' .. hl_name .. '#'
     elseif type(color) == 'table' then
       if not highlight.no_default and not (color.fg and color.bg) then
-        hl_name = append_mode(hl_name, is_focused)
-        color = get_default_component_color(hl_name, mode, highlight.section, color, highlight.options)
+        local hl = vim.deepcopy(highlight)
+        hl.name = append_mode(hl.name, is_focused)
+        color = get_default_component_color(hl, append_mode(''):sub(2), highlight.section, color, highlight.options)
       end
       M.highlight(hl_name, color.fg, color.bg, color.gui, nil)
       return '%#' .. hl_name .. '#'

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -304,7 +304,7 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
 
   local tag_id = 0
   while
-    M.highlight_exists(table.concat({ 'lualine', highlight_tag }, '_'))
+    M.highlight_exists(table.concat({ 'lualine', section, highlight_tag }, '_'))
     or (section and M.highlight_exists(table.concat({ 'lualine', section, highlight_tag, 'normal' }, '_')))
   do
     highlight_tag = highlight_tag .. '_' .. tostring(tag_id)

--- a/lua/lualine/utils/loader.lua
+++ b/lua/lualine/utils/loader.lua
@@ -91,7 +91,7 @@ component type '%s' isn't recognised. Check if spelling is correct.]],
 end
 
 --- Shows notice about invalid types passed as component
---- @param index number the index of component jn section table
+--- @param index number the index of component in section table
 --- @param component table containing component elements
 --- return bool whether check passed or not
 local function is_valid_component_type(index, component)
@@ -141,7 +141,7 @@ local function load_sections(sections, options)
       end
       if is_valid_component_type(index, component) then
         component.self = {}
-        component.self.section = section_name
+        component.self.section = section_name:match('lualine_(.*)')
         -- apply default args
         component = vim.tbl_extend('keep', component, options)
         section[index] = component_loader(component)

--- a/lua/lualine/utils/section.lua
+++ b/lua/lualine/utils/section.lua
@@ -15,7 +15,7 @@ local highlight = require('lualine.highlight')
 ---@return string formated string for a section
 --TODO Clean this up this does lots of messy stuff.
 function M.draw_section(section, section_name, is_focused)
-  local highlight_name = highlight.format_highlight('lualine_' .. section_name, is_focused)
+  local highlight_name = highlight.format_highlight(section_name, is_focused)
 
   local status = {}
   for _, component in pairs(section) do

--- a/lua/lualine/utils/section.lua
+++ b/lua/lualine/utils/section.lua
@@ -26,6 +26,8 @@ function M.draw_section(section, section_name, is_focused)
     table.insert(status, component:draw(highlight_name, is_focused))
   end
 
+  local section_color = utils.extract_highlight_colors(string.match(highlight_name, '%%#(.*)#'))
+
   -- Flags required for knowing when to remove component separator
   local strip_next_component = false
   local last_component_found = false
@@ -60,12 +62,17 @@ function M.draw_section(section, section_name, is_focused)
     end
     -- Remove component separator when color option is used to color background
     if
-      (type(section[component_no].options.color) == 'table' and section[component_no].options.color.bg)
+      (
+        type(section[component_no].options.color) == 'table'
+        and section[component_no].options.color.bg
+        and section[component_no].options.color.bg ~= section_color.bg
+      )
       or type(section[component_no].options.color) == 'string'
       or (
         type(section[component_no].options.color) == 'function'
         and section[component_no].color_fn_cache
         and section[component_no].color_fn_cache.bg
+        and section[component_no].color_fn_cache.bg ~= section_color.bg
       )
     then
       strip_next_component = true

--- a/lua/lualine/utils/section.lua
+++ b/lua/lualine/utils/section.lua
@@ -62,6 +62,11 @@ function M.draw_section(section, section_name, is_focused)
     if
       (type(section[component_no].options.color) == 'table' and section[component_no].options.color.bg)
       or type(section[component_no].options.color) == 'string'
+      or (
+        type(section[component_no].options.color) == 'function'
+        and section[component_no].color_fn_cache
+        and section[component_no].color_fn_cache.bg
+      )
     then
       strip_next_component = true
       status[component_no] = section[component_no]:strip_separator()

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -9,17 +9,20 @@ local M = {}
 ---@return table|string returns #rrggbb formated color when scope is specified
 ----                       or comolete color table when scope isn't specified
 function M.extract_highlight_colors(color_group, scope)
-  if vim.fn.hlexists(color_group) == 0 then
-    return nil
-  end
-  local color = vim.api.nvim_get_hl_by_name(color_group, true)
-  if color.background ~= nil then
-    color.bg = string.format('#%06x', color.background)
-    color.background = nil
-  end
-  if color.foreground ~= nil then
-    color.fg = string.format('#%06x', color.foreground)
-    color.foreground = nil
+  local color = require('lualine.highlight').get_lualine_hl(color_group)
+  if not color then
+    if vim.fn.hlexists(color_group) == 0 then
+      return nil
+    end
+    color = vim.api.nvim_get_hl_by_name(color_group, true)
+    if color.background ~= nil then
+      color.bg = string.format('#%06x', color.background)
+      color.background = nil
+    end
+    if color.foreground ~= nil then
+      color.fg = string.format('#%06x', color.foreground)
+      color.foreground = nil
+    end
   end
   if scope then
     return color[scope]

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -49,7 +49,7 @@ M.build_component_opts = function(opts)
     end
   end
   if not opts.self then
-    opts.self = { section = 'lualine_c' }
+    opts.self = { section = 'c' }
   end
   if not opts.theme then
     opts.theme = 'gruvbox'

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -29,10 +29,10 @@ function M.init_component(component, opts)
 end
 
 -- Checks ouput of a component
-M.assert_component = function(component, opts, result)
+M.assert_component = function(component, opts, result, is_active)
   local comp = M.init_component(component, opts)
   -- for testing global options
-  eq(result, comp:draw(opts.hl))
+  eq(result, comp:draw(opts.hl, is_active or true))
 end
 
 function M.assert_component_instence(comp, result)

--- a/lua/tests/spec/component_spec.lua
+++ b/lua/tests/spec/component_spec.lua
@@ -292,11 +292,12 @@ describe('Filetype component', function()
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
+      hl = '%#lualine_c_normal#',
       padding = 0,
       colored = true,
       icon_only = false,
     }
-    assert_component('filetype', opts, '%#MyCompHl_normal#*%#lualine_c_normal# lua')
+    assert_component('filetype', opts, '%#MyCompHl_normal#*%#lualine_c_normal# lua%#lualine_c_normal#')
     assert.stub(utils.extract_highlight_colors).was_called_with('test_highlight_group', 'fg')
     assert.stub(hl.create_component_highlight_group).was_called_with({ fg = '#000' }, 'test_highlight_group', opts)
     hl.create_component_highlight_group:revert()

--- a/lua/tests/spec/component_spec.lua
+++ b/lua/tests/spec/component_spec.lua
@@ -186,7 +186,7 @@ describe('Component:', function()
         color = 'MyHl',
       }
       local comp = require('lualine.components.special.function_component')(opts)
-      local custom_link_hl_name = 'lualine_' .. comp.options.component_name .. '_no_mode'
+      local custom_link_hl_name = 'lualine_' .. comp.options.component_name
       eq('%#' .. custom_link_hl_name .. '#test', comp:draw(opts.hl))
       local opts2 = build_component_opts {
         component_separators = { left = '', right = '' },
@@ -284,8 +284,10 @@ describe('Filetype component', function()
     local hl = require('lualine.highlight')
     local utils = require('lualine.utils.utils')
     stub(hl, 'create_component_highlight_group')
+    stub(hl, 'format_highlight')
     stub(utils, 'extract_highlight_colors')
     hl.create_component_highlight_group.returns { name = 'MyCompHl', no_mode = false, section = 'a' }
+    hl.format_highlight.returns('%#lualine_c_normal#')
     utils.extract_highlight_colors.returns('#000')
 
     local opts = build_component_opts {
@@ -298,6 +300,7 @@ describe('Filetype component', function()
     assert.stub(utils.extract_highlight_colors).was_called_with('test_highlight_group', 'fg')
     assert.stub(hl.create_component_highlight_group).was_called_with({ fg = '#000' }, 'test_highlight_group', opts)
     hl.create_component_highlight_group:revert()
+    hl.format_highlight:revert()
     utils.extract_highlight_colors:revert()
     package.loaded['nvim-web-devicons'] = nil
     vim.g.actual_curwin = nil

--- a/lua/tests/spec/component_spec.lua
+++ b/lua/tests/spec/component_spec.lua
@@ -15,7 +15,7 @@ describe('Component:', function()
     local comp = require('lualine.components.special.function_component')(opts)
     -- correct for lualine_c
     eq('', comp.options.separator)
-    local opts2 = build_component_opts { self = { section = 'lualine_y' } }
+    local opts2 = build_component_opts { self = { section = 'y' } }
     local comp2 = require('lualine.components.special.function_component')(opts2)
     -- correct for lualine_u
     eq('', comp2.options.separator)

--- a/lua/tests/spec/component_spec.lua
+++ b/lua/tests/spec/component_spec.lua
@@ -280,12 +280,12 @@ describe('Filetype component', function()
         return '*', 'test_highlight_group'
       end,
     }
-
+    vim.g.actual_curwin = tostring(vim.api.nvim_get_current_win())
     local hl = require('lualine.highlight')
     local utils = require('lualine.utils.utils')
     stub(hl, 'create_component_highlight_group')
     stub(utils, 'extract_highlight_colors')
-    hl.create_component_highlight_group.returns('MyCompHl')
+    hl.create_component_highlight_group.returns { name = 'MyCompHl', no_mode = false, section = 'a' }
     utils.extract_highlight_colors.returns('#000')
 
     local opts = build_component_opts {
@@ -300,6 +300,7 @@ describe('Filetype component', function()
     hl.create_component_highlight_group:revert()
     utils.extract_highlight_colors:revert()
     package.loaded['nvim-web-devicons'] = nil
+    vim.g.actual_curwin = nil
   end)
 
   it("Doesn't color when colored is false", function()

--- a/lua/tests/spec/component_spec.lua
+++ b/lua/tests/spec/component_spec.lua
@@ -40,7 +40,12 @@ describe('Component:', function()
     -- color highlight wan't in options when create_comp_hl was
     -- called so remove it before assert
     comp1.options.color_highlight = nil
-    assert.stub(hl.create_component_highlight_group).was_called_with(color, comp1.options.component_name, comp1.options)
+    assert.stub(hl.create_component_highlight_group).was_called_with(
+      color,
+      comp1.options.component_name,
+      comp1.options,
+      false
+    )
     hl.create_component_highlight_group:revert()
     color = 'MyHl'
     local opts2 = build_component_opts { color = color }
@@ -51,7 +56,12 @@ describe('Component:', function()
     -- color highlight wan't in options when create_comp_hl was
     -- called so remove it before assert
     comp2.options.color_highlight = nil
-    assert.stub(hl.create_component_highlight_group).was_called_with(color, comp2.options.component_name, comp2.options)
+    assert.stub(hl.create_component_highlight_group).was_called_with(
+      color,
+      comp2.options.component_name,
+      comp2.options,
+      false
+    )
     hl.create_component_highlight_group:revert()
   end)
 
@@ -186,7 +196,7 @@ describe('Component:', function()
         color = 'MyHl',
       }
       local comp = require('lualine.components.special.function_component')(opts)
-      local custom_link_hl_name = 'lualine_' .. comp.options.component_name
+      local custom_link_hl_name = 'lualine_c_' .. comp.options.component_name
       eq('%#' .. custom_link_hl_name .. '#test', comp:draw(opts.hl))
       local opts2 = build_component_opts {
         component_separators = { left = '', right = '' },
@@ -299,7 +309,12 @@ describe('Filetype component', function()
     }
     assert_component('filetype', opts, '%#MyCompHl_normal#*%#lualine_c_normal# lua%#lualine_c_normal#')
     assert.stub(utils.extract_highlight_colors).was_called_with('test_highlight_group', 'fg')
-    assert.stub(hl.create_component_highlight_group).was_called_with({ fg = '#000' }, 'test_highlight_group', opts)
+    assert.stub(hl.create_component_highlight_group).was_called_with(
+      { fg = '#000' },
+      'test_highlight_group',
+      opts,
+      false
+    )
     hl.create_component_highlight_group:revert()
     hl.format_highlight:revert()
     utils.extract_highlight_colors:revert()

--- a/lua/tests/spec/utils_spec.lua
+++ b/lua/tests/spec/utils_spec.lua
@@ -66,6 +66,7 @@ describe('Section genarator', function()
   end)
 
   it('can remove separators from component with custom colors', function()
+    vim.g.actual_curwin = tostring(vim.api.nvim_get_current_win())
     local opts = build_component_opts { section_separators = { left = '', right = '' } }
     local opts_colored = build_component_opts { color = 'MyColor' }
     local opts_colored2 = build_component_opts {
@@ -104,5 +105,6 @@ describe('Section genarator', function()
         .. ' test %#lualine_MySection_normal#%#lualine_MySection_normal# test ',
       sec.draw_section(section, 'MySection')
     )
+    vim.g.actual_curwin = nil
   end)
 end)

--- a/lua/tests/spec/utils_spec.lua
+++ b/lua/tests/spec/utils_spec.lua
@@ -74,7 +74,9 @@ describe('Section genarator', function()
 
   it('can remove separators from component with custom colors', function()
     stub(hl, 'format_highlight')
+    stub(hl, 'get_lualine_hl')
     hl.format_highlight.returns('%#lualine_MySection_normal#')
+    hl.get_lualine_hl.returns { fg = '#000000', bg = '#ffffff' }
 
     vim.g.actual_curwin = tostring(vim.api.nvim_get_current_win())
     local opts = build_component_opts { section_separators = { left = '', right = '' } }
@@ -118,5 +120,6 @@ describe('Section genarator', function()
     vim.g.actual_curwin = nil
 
     hl.format_highlight:revert()
+    hl.get_lualine_hl:revert()
   end)
 end)

--- a/lua/tests/spec/utils_spec.lua
+++ b/lua/tests/spec/utils_spec.lua
@@ -95,7 +95,7 @@ describe('Section genarator', function()
       require('lualine.components.special.function_component')(opts_colored),
       require('lualine.components.special.function_component')(opts),
     }
-    local highlight_name2 = 'lualine_' .. section[2].options.component_name
+    local highlight_name2 = 'lualine_c_' .. section[2].options.component_name
     -- Removes separator on string color
     eq(
       '%#lualine_MySection_normal# test %#' .. highlight_name2 .. '#' .. ' test %#lualine_MySection_normal# test ',


### PR DESCRIPTION
Now you can use function that return the color definitions in any kind of color options (And yes in themes too)

For example here's how mode component is defined in `examples/evilline.lua` now
```lua
{  function() return '' end,
  color = function()
    -- auto change color according to neovims mode
    local mode_color = {
      n = colors.red,
      i = colors.green,
      v = colors.blue,
      [''] = colors.blue,
      V = colors.blue,
      c = colors.magenta,
      no = colors.red,
      s = colors.orange,
      S = colors.orange,
      [''] = colors.orange,
      ic = colors.yellow,
      R = colors.violet,
      Rv = colors.violet,
      cv = colors.red,
      ce = colors.red,
      r = colors.cyan,
      rm = colors.cyan,
      ['r?'] = colors.cyan,
      ['!'] = colors.red,
      t = colors.red,
    }
    return { fg = mode_color[vim.fn.mode()] }
  end,
}
```