### PR TITLE
feat: add onedark/onelight command mode color

### DIFF
--- a/lua/lualine/themes/onedark.lua
+++ b/lua/lualine/themes/onedark.lua
@@ -22,7 +22,7 @@ return {
     b = { fg = colors.fg, bg = colors.gray3 },
     c = { fg = colors.fg, bg = colors.gray2 },
   },
-  command = { a = { fg = colors.bg, bg = colors.yellow, gui = 'boid' } },
+  command = { a = { fg = colors.bg, bg = colors.yellow, gui = 'bold' } },
   insert = { a = { fg = colors.bg, bg = colors.blue, gui = 'bold' } },
   visual = { a = { fg = colors.bg, bg = colors.purple, gui = 'bold' } },
   replace = { a = { fg = colors.bg, bg = colors.red1, gui = 'bold' } },

--- a/lua/lualine/themes/onedark.lua
+++ b/lua/lualine/themes/onedark.lua
@@ -22,6 +22,7 @@ return {
     b = { fg = colors.fg, bg = colors.gray3 },
     c = { fg = colors.fg, bg = colors.gray2 },
   },
+  command = { a = { fg = colors.bg, bg = colors.yellow, gui = 'boid' } },
   insert = { a = { fg = colors.bg, bg = colors.blue, gui = 'bold' } },
   visual = { a = { fg = colors.bg, bg = colors.purple, gui = 'bold' } },
   replace = { a = { fg = colors.bg, bg = colors.red1, gui = 'bold' } },

--- a/lua/lualine/themes/onelight.lua
+++ b/lua/lualine/themes/onelight.lua
@@ -22,7 +22,7 @@ return {
     b = { fg = colors.fg, bg = colors.gray3 },
     c = { fg = colors.fg, bg = colors.gray2 },
   },
-  command = { a = { fg = colors.bg, bg = colors.yellow, gui = 'boid' } },
+  command = { a = { fg = colors.bg, bg = colors.yellow, gui = 'bold' } },
   insert = { a = { fg = colors.bg, bg = colors.blue, gui = 'bold' } },
   visual = { a = { fg = colors.bg, bg = colors.purple, gui = 'bold' } },
   replace = { a = { fg = colors.bg, bg = colors.red1, gui = 'bold' } },

--- a/lua/lualine/themes/onelight.lua
+++ b/lua/lualine/themes/onelight.lua
@@ -22,6 +22,7 @@ return {
     b = { fg = colors.fg, bg = colors.gray3 },
     c = { fg = colors.fg, bg = colors.gray2 },
   },
+  command = { a = { fg = colors.bg, bg = colors.yellow, gui = 'boid' } },
   insert = { a = { fg = colors.bg, bg = colors.blue, gui = 'bold' } },
   visual = { a = { fg = colors.bg, bg = colors.purple, gui = 'bold' } },
   replace = { a = { fg = colors.bg, bg = colors.red1, gui = 'bold' } },


### PR DESCRIPTION
Since no command mode color was specified for onedark / onelight, I set the unused yellow.
