### PR TITLE
fix Palenight theme modal color assignments

### DIFF
--- a/lua/lualine/themes/palenight.lua
+++ b/lua/lualine/themes/palenight.lua
@@ -23,16 +23,16 @@ local colors = {
 
 return {
   normal = {
-    a = { fg = colors.black, bg = colors.purple, gui = 'bold' },
+    a = { fg = colors.black, bg = colors.cyan, gui = 'bold' },
     b = { fg = colors.purple, bg = colors.menu_grey },
     c = { fg = colors.comment_grey, bg = colors.black },
   },
   insert = {
-    a = { fg = colors.black, bg = colors.blue, gui = 'bold' },
+    a = { fg = colors.black, bg = colors.purple, gui = 'bold' },
     b = { fg = colors.blue, bg = colors.menu_grey },
   },
   visual = {
-    a = { fg = colors.black, bg = colors.cyan, gui = 'bold' },
+    a = { fg = colors.black, bg = colors.blue, gui = 'bold' },
     b = { fg = colors.cyan, bg = colors.menu_grey },
   },
   replace = {


### PR DESCRIPTION
This changes around what  color each mode indicator is in the palenight theme. These colors are more consistent with palenight/material themes of other statuslines