### PR TITLE
Support global statusline

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -269,10 +269,8 @@ local function set_statusline()
   if next(config.sections) ~= nil or next(config.inactive_sections) ~= nil then
     vim.cmd('autocmd lualine VimResized * redrawstatus')
     vim.go.statusline = "%{%v:lua.require'lualine'.statusline()%}"
-    vim.go.laststatus = 2
   elseif vim.go.statusline == "%{%v:lua.require'lualine'.statusline()%}" then
     vim.go.statusline = nil
-    vim.go.laststatus = 2
   end
 end
 


### PR DESCRIPTION
This PR removes defaults for `laststatus` in `lualine.nvim` and requires users to set `laststatus` manually in their configuration. 

The default for `laststatus` is 2:

```
					*'laststatus'* *'ls'*
'laststatus' 'ls'	number	(default 2)
			global
	The value of this option influences when the last window will have a
	status line:
		0: never
		1: only if there are at least two windows
		2: always
		3: have a global statusline at the bottom instead of one for
		   each window
	The screen looks nicer with a status line if you have several
	windows, but it takes another screen line. |status-line|
```

So this PR should have no effect on existing user's setup.

Merging this will allow for global status line using:

```
vim.opt.laststatus = 3
```

Fixes #611 