### PR TITLE
fix(filename): use columns for shortening if using global statusline

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -55,7 +55,7 @@ M.update_status = function(self)
   end
 
   if self.options.shorting_target ~= 0 then
-    local windwidth = vim.fn.winwidth(0)
+    local windwidth = self.options.globalstatus and vim.go.columns or vim.fn.winwidth(0)
     local estimated_space_available = windwidth - self.options.shorting_target
 
     local path_separator = package.config:sub(1, 1)


### PR DESCRIPTION
After https://github.com/nvim-lualine/lualine.nvim/pull/613 , I think shortening target calculation should be based on `columns` option if using `globalstatus`, otherwise, `filename` shortening occurs when we open a new split

> Enabling global statusline, shortening based on window width

![20220318_203631_full](https://user-images.githubusercontent.com/55179750/159006362-f504262a-7ddf-485f-aebf-22393fc1b8a4.jpg)

---

> Global statusline, shortening based on `columns` option

![20220318_203724_full](https://user-images.githubusercontent.com/55179750/159006588-4e96cda2-387b-4ae5-a9e9-aeff679145b1.jpg)
