### PR TITLE
Evil: Display up to 3 lsp names

### DIFF
--- a/examples/evil_lualine.lua
+++ b/examples/evil_lualine.lua
@@ -158,17 +158,29 @@ ins_left {
 ins_left {
   -- Lsp server name .
   function()
-    local msg = 'No Active Lsp'
     local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
     local clients = vim.lsp.get_active_clients()
     if next(clients) == nil then
-      return msg
+      return 'No Active Lsp'
     end
+    local clientNames = {}
     for _, client in ipairs(clients) do
       local filetypes = client.config.filetypes
       if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
-        return client.name
+        table.insert(clientNames, client.name)
       end
+    end
+    if #clientNames == 0 then
+      return 'No Active Lsp'
+    end
+    local msg = ''
+    local maxClientsToPrint = 3
+    local separator = '·'
+    for i = 1, math.min(maxClientsToPrint, #clientNames) do
+      msg = msg..(i == 1 and '' or separator)..clientNames[i]
+    end
+    if #clientNames > maxClientsToPrint then
+      msg = msg..separator..'+'..(#clientNames - maxClientsToPrint)
     end
     return msg
   end,


### PR DESCRIPTION
When multiple LSP clients are active on a buffer, display the first 3 names in full.

When more than 3 LSP clients are active, display a "+X" suffix (where "X" is the number of additional clients not displayed).

**4 LSP clients** _(new)_
![Screenshot from 2022-03-22 16-29-49](https://user-images.githubusercontent.com/612020/159414322-80fd19f8-f1a3-4915-94c0-b44fae5119b4.png)

**1 LSP client** _(existing behaviour)_
![Screenshot from 2022-03-22 16-30-01](https://user-images.githubusercontent.com/612020/159414348-c02b502a-0778-4f88-8543-cf7258b096f7.png)

**No LSP clients** _(existing behaviour)_
![Screenshot from 2022-03-22 16-30-44](https://user-images.githubusercontent.com/612020/159414400-0b759b26-04ee-49fe-bbf9-297688dd1a9a.png)
