### PR TITLE
Fix #623: 'None' erroneously interpreted as hex-color => '#None' error

### DIFF
--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -53,7 +53,7 @@ end
 ---@param color string|number
 ---@return string
 local function sanitize_color(color)
-  if color == nil or color == '' then
+  if color == nil or color == '' or color == 'None' then
     return 'None'
   end
   if type(color) == 'string' then


### PR DESCRIPTION
As described in #623 the ``rgb2cterm`` function  in color_utils.lua is passed "#None" for "None", leading to the bug in 623.
This happens because ``sanitize_color`` in highlight.lua erronously assumes 'None' to be a hex color and therefore prefixes it with a # to '#None'.
This PR restores the behavior of ``sanitize_color`` to re-allow None being set as a color