### PR TITLE
feat: show index in buffers component instead of bufnr

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ sections = {
       show_modified_status = true, -- Shows indicator when the buffer is modified.
 
       mode = 0, -- 0: Shows buffer name
-                -- 1: Shows buffer index (bufnr)
-                -- 2: Shows buffer name + buffer index (bufnr)
+                -- 1: Shows buffer index
+                -- 2: Shows buffer name + buffer index
 
       max_length = vim.o.columns * 2 / 3, -- Maximum width of buffers component,
                                           -- it can also be a function that returns
@@ -609,8 +609,8 @@ sections = {
       show_modified_status = true, -- Shows indicator when the window is modified.
 
       mode = 0, -- 0: Shows window name
-                -- 1: Shows window index (bufnr)
-                -- 2: Shows window name + window index (bufnr)
+                -- 1: Shows window index
+                -- 2: Shows window name + window index
 
       max_length = vim.o.columns * 2 / 3, -- Maximum width of windows component,
                                           -- it can also be a function that returns
@@ -672,6 +672,12 @@ tabline = {
 Shows currently open buffers. Like bufferline . See
 [buffers options](#buffers-component-options)
 for all builtin behaviors of buffers component.
+You can use `:LualineBuffersJump` to jump to buffer based on index
+of buffer in buffers component.
+```vim
+  :LualineBuffersJump 2  " Jumps to 2nd buffer in buffers component.
+  :LualineBuffersJump $  " Jumps to last buffer in buffers component.
+```
 
 #### Tabs
 Shows currently open tab. Like usual tabline. See

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -454,8 +454,8 @@ Component specific options             These are options that are available on
           show_modified_status = true, -- Shows indicator when the buffer is modified.
     
           mode = 0, -- 0: Shows buffer name
-                    -- 1: Shows buffer index (bufnr)
-                    -- 2: Shows buffer name + buffer index (bufnr)
+                    -- 1: Shows buffer index
+                    -- 2: Shows buffer name + buffer index
     
           max_length = vim.o.columns * 2 / 3, -- Maximum width of buffers component,
                                               -- it can also be a function that returns
@@ -633,8 +633,8 @@ Component specific options             These are options that are available on
           show_modified_status = true, -- Shows indicator when the window is modified.
     
           mode = 0, -- 0: Shows window name
-                    -- 1: Shows window index (bufnr)
-                    -- 2: Shows window name + window index (bufnr)
+                    -- 1: Shows window index
+                    -- 2: Shows window name + window index
     
           max_length = vim.o.columns * 2 / 3, -- Maximum width of windows component,
                                               -- it can also be a function that returns
@@ -703,6 +703,15 @@ Buffers                                Shows currently open buffers. Like
                                        bufferline. See
                                        |lualine-buffers-options| for all
                                        builtin behaviors of buffers component.
+                                       You can use `:LualineBuffersJump` to
+                                       jump to buffer based on index of buffer
+                                       in buffers component.
+
+
+>
+      :LualineBuffersJump 2  " Jumps to 2nd buffer in buffers component.
+      :LualineBuffersJump $  " Jumps to last buffer in buffers component.
+<
 
 
                                                                 *lualine-Tabs*

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -10,6 +10,7 @@ local modules = require('lualine_require').lazy_require {
 function Buffer:init(opts)
   assert(opts.bufnr, 'Cannot create Buffer without bufnr')
   self.bufnr = opts.bufnr
+  self.buf_index = opts.buf_index
   self.options = opts.options
   self.highlights = opts.highlights
   self:get_props()
@@ -156,7 +157,10 @@ function Buffer:apply_mode(name)
     return string.format('%s %s%s', self.bufnr, self.icon, self.modified_icon)
   end
 
-  return string.format('%s %s%s%s', self.bufnr, self.icon, name, self.modified_icon)
+  if self.options.mode == 2 then
+    return string.format('%s %s%s%s', self.bufnr, self.icon, name, self.modified_icon)
+  end
+  return string.format('%s %s%s%s', self.buf_index, self.icon, name, self.modified_icon)
 end
 
 return Buffer

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -154,13 +154,10 @@ function Buffer:apply_mode(name)
   end
 
   if self.options.mode == 1 then
-    return string.format('%s %s%s', self.bufnr, self.icon, self.modified_icon)
+    return string.format('%s %s%s', self.buf_index or '', self.icon, self.modified_icon)
   end
 
-  if self.options.mode == 2 then
-    return string.format('%s %s%s%s', self.bufnr, self.icon, name, self.modified_icon)
-  end
-  return string.format('%s %s%s%s', self.buf_index, self.icon, name, self.modified_icon)
+  return string.format('%s %s%s%s', self.buf_index or '', self.icon, name, self.modified_icon)
 end
 
 return Buffer

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -66,11 +66,12 @@ function M:init(options)
   end
 end
 
-function M:new_buffer(bufnr)
+function M:new_buffer(bufnr, buf_index)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
-
+  buf_index = buf_index or ''
   return Buffer:new {
     bufnr = bufnr,
+    buf_index = buf_index,
     options = self.options,
     highlights = self.highlights,
   }
@@ -80,7 +81,7 @@ function M:buffers()
   local buffers = {}
   for b = 1, vim.fn.bufnr('$') do
     if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
-      buffers[#buffers + 1] = self:new_buffer(b)
+      buffers[#buffers + 1] = self:new_buffer(b, #buffers + 1)
     end
   end
 

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -79,9 +79,11 @@ end
 
 function M:buffers()
   local buffers = {}
+  M.bufpos2nr = {}
   for b = 1, vim.fn.bufnr('$') do
     if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
       buffers[#buffers + 1] = self:new_buffer(b, #buffers + 1)
+      M.bufpos2nr[#buffers] = b
     end
   end
 
@@ -213,10 +215,24 @@ function M:draw()
   return self.status
 end
 
+function M.buffer_jump(buf_pos)
+  if buf_pos == '$' then
+    buf_pos = #M.bufpos2nr
+  else
+    buf_pos = tonumber(buf_pos)
+  end
+  if buf_pos < 1 or buf_pos > #M.bufpos2nr then
+    error('Error: Unable to jump buffer position out of range')
+  end
+  vim.api.nvim_set_current_buf(M.bufpos2nr[buf_pos])
+end
+
 vim.cmd([[
   function! LualineSwitchBuffer(bufnr, mouseclicks, mousebutton, modifiers)
     execute ":buffer " . a:bufnr
   endfunction
+
+  command! -nargs=1 LualineBuffersJump call v:lua.require'lualine.components.buffers'.buffer_jump(<f-args>)
 ]])
 
 return M


### PR DESCRIPTION
**Features:**
 Neovim's bufnr sometimes may very strange when it's number not as same as the order of buffers component. So I add buffer index, which index is as same as buffers component.
![图片](https://user-images.githubusercontent.com/23305067/160331456-0b8b0634-fa98-4d64-84b5-7c9060bb0288.png)
In this picture, you can see the number of buffer component are different from bufnr.
I wont delete code about bufnr, I just add buffer index.
