### PR TITLE
feat: hide filename extension for buffers component

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ sections = {
     {
       'buffers',
       show_filename_only = true,   -- Shows shortened relative path when set to false.
+      hide_filename_extension = false,   -- Hide filename extension when set to true.
       show_modified_status = true, -- Shows indicator when the buffer is modified.
 
       mode = 0, -- 0: Shows buffer name

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -132,8 +132,17 @@ function Buffer:name()
   elseif self.file == '' then
     return '[No Name]'
   end
-  return self.options.show_filename_only and vim.fn.fnamemodify(self.file, ':t')
-    or vim.fn.pathshorten(vim.fn.fnamemodify(self.file, ':p:.'))
+
+  local name
+  if self.options.show_filename_only then
+    name = vim.fn.fnamemodify(self.file, ':t')
+  else
+    name = vim.fn.pathshorten(vim.fn.fnamemodify(self.file, ':p:.'))
+  end
+  if self.options.hide_filename_extension then
+    name = vim.fn.fnamemodify(name, ':r')
+  end
+  return name
 end
 
 ---adds spaces to left and right

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -7,6 +7,7 @@ local highlight = require('lualine.highlight')
 
 local default_options = {
   show_filename_only = true,
+  hide_filename_extension = false,
   show_modified_status = true,
   mode = 0,
   max_length = 0,


### PR DESCRIPTION
Add an option `hide_filename_extension` to `buffers` components.
The file kind icon already indicates filetype. Hidng extensions can save more spaces.

<img width="470" alt="CleanShot 2022-03-29 at 18 31 47@2x" src="https://user-images.githubusercontent.com/2283394/160592906-b79ec084-d6a7-4dcc-97a2-378e5c30ddce.png">

