### PR TITLE
feat: live filesize

### DIFF
--- a/lua/lualine/components/filesize.lua
+++ b/lua/lualine/components/filesize.lua
@@ -1,15 +1,7 @@
 -- Copyright (c) 2020-2021 shadmansaleh
 -- MIT license, see LICENSE for more details.
 local function filesize()
-  local file = vim.fn.expand('%:p')
-  if file == nil or #file == 0 then
-    return ''
-  end
-
-  local size = vim.fn.getfsize(file)
-  if size <= 0 then
-    return ''
-  end
+  local size = vim.fn.wordcount().bytes
 
   local sufixes = { 'b', 'k', 'm', 'g' }
 

--- a/lua/lualine/components/filesize.lua
+++ b/lua/lualine/components/filesize.lua
@@ -3,16 +3,16 @@
 local function filesize()
   local size = vim.fn.wordcount().bytes
 
-  local sufixes = { 'b', 'k', 'm', 'g' }
+  local suffixes = { 'b', 'k', 'm', 'g' }
 
   local i = 1
-  while size > 1024 and i < #sufixes do
+  while size > 1024 and i < #suffixes do
     size = size / 1024
     i = i + 1
   end
 
   local format = i == 1 and '%d%s' or '%.1f%s'
-  return string.format(format, size, sufixes[i])
+  return string.format(format, size, suffixes[i])
 end
 
 return filesize

--- a/lua/lualine/components/filesize.lua
+++ b/lua/lualine/components/filesize.lua
@@ -11,7 +11,8 @@ local function filesize()
     i = i + 1
   end
 
-  return string.format('%.1f%s', size, sufixes[i])
+  local format = i == 1 and '%d%s' or '%.1f%s'
+  return string.format(format, size, sufixes[i])
 end
 
 return filesize


### PR DESCRIPTION
Hi! I changed the filesize component a bit so the filesize is always up-to-date by using vim.fn.wordcount().bytes. I removed the decimal for the bytes, since I don't think you can have half a byte, and I fixed a typo. Let me know what you think!

See preview:
[![asciicast](https://asciinema.org/a/qyrJ9MVTdf7hPVh7qpFEcVo1S.svg)](https://asciinema.org/a/qyrJ9MVTdf7hPVh7qpFEcVo1S)