### PR TITLE
Adds option to start counting buffers from custom index

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ sections = {
                 -- 1: Shows buffer index
                 -- 2: Shows buffer name + buffer index
 
+      first_index = 1,  -- Start counting buffer indices from this number
       max_length = vim.o.columns * 2 / 3, -- Maximum width of buffers component,
                                           -- it can also be a function that returns
                                           -- the value of `max_length` dynamically.

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -183,4 +183,15 @@ function M.stl_escape(str)
   return str:gsub('%%', '%%%%')
 end
 
+---Count the number of non-nil values in table
+---@param table table
+---@return integer
+function M.list_count(table)
+  local size = 0
+  for k, v in pairs(table) do
+    size = size + 1
+  end
+  return size
+end
+
 return M


### PR DESCRIPTION
This PR adds an option to the buffers component to start counting the buffers from a custom index. This is inspired by airline. This is useful for instance if the user wants to create mappings like `<leader>BUF_INDEX`. As it stands now, the user has to create mappings for indices starting from 1 as the counting starts from there. But, a mapping of `<leader>1` and one of `<leader>10` will "confilct" and there will be a delay in choosing buffer #1. This is quite unbearable as the numbers 1-9 are the ones that will always be available and there will always be a delay when switching buffers with such mappings unless a buffer with index >=10 is to be selected. 