### PR TITLE
feat: add option to invert component icon alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ sections = {
       -- As table it must contain the icon as first entry and can use
       -- color option to custom color the icon. Example:
       -- {'branch', icon = ''} / {'branch', icon = {'', color={fg='green'}}}
+
+      -- icon position can also be set to the right side from table. Example:
+      -- {'branch', icon = {'', align='right', color={fg='green'}}}
       icon = nil,
 
       separator = nil,      -- Determines what separator to use for the component.
@@ -568,7 +571,10 @@ sections = {
     {
       'filetype',
       colored = true,   -- Displays filetype icon in color if set to true
-      icon_only = false -- Display only an icon for filetype
+      icon_only = false, -- Display only an icon for filetype
+      icon = { align = 'right' }, -- Display filetype icon on the right hand side
+      -- icon =    {'X', align='right'}
+      -- Icon string ^ in table is ignored in filetype component
     }
   }
 }

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -115,16 +115,25 @@ function M:apply_icon()
   local icon = self.options.icon
   if self.options.icons_enabled and icon then
     if type(icon) == 'table' then
+      self.options.icon_alignment = icon.align
       icon = icon[1]
     end
-    if self.options.icon_color_highlight then
-      self.status = table.concat({
+    if self.options.icon_color_highlight and self.options.icon_alignment == 'right' then
+      self.status = table.concat {
+        self.status,
+        ' ',
+        self:format_hl(self.options.icon_color_highlight),
+        icon,
+        self:get_default_hl(),
+      }
+    elseif self.options.icon_color_highlight then
+      self.status = table.concat {
         self:format_hl(self.options.icon_color_highlight),
         icon,
         self:get_default_hl(),
         ' ',
         self.status,
-      })
+      }
     elseif self.options.icon_alignment == 'right' then
       self.status = table.concat({ self.status, icon }, ' ')
     else

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -132,7 +132,7 @@ function M:apply_icon()
         ' ',
         self.status,
       }
-    elseif self.options.icon_alignment == 'right' then
+    elseif type(self.options.icon) == 'table' and self.options.icon.align == 'right' then
       self.status = table.concat({ self.status, icon }, ' ')
     else
       self.status = table.concat({ icon, self.status }, ' ')

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -76,7 +76,9 @@ function M:apply_padding()
       -- When component has changed the highlight at begining
       -- we will add the padding after the highlight
       local pre_highlight = vim.fn.matchlist(self.status, [[\(%#.\{-\}#\)]])[2]
-      self.status = pre_highlight .. string.rep(' ', l_padding) .. self.status:sub(#pre_highlight + 1, #self.status)
+      self.status = pre_highlight
+        .. string.rep(' ', l_padding)
+        .. self.status:sub(#pre_highlight + 1, #self.status)
     else
       self.status = string.rep(' ', l_padding) .. self.status
     end
@@ -108,7 +110,7 @@ function M:apply_highlights(default_highlight)
   end
 end
 
----apply icon in front of component (prepemds component with icon)
+---apply icon to component (appends/prepemds component with icon)
 function M:apply_icon()
   local icon = self.options.icon
   if self.options.icons_enabled and icon then
@@ -116,14 +118,14 @@ function M:apply_icon()
       icon = icon[1]
     end
     if self.options.icon_color_highlight then
-      self.status = table.concat {
+      self.status = table.concat({
         self:format_hl(self.options.icon_color_highlight),
         icon,
         self:get_default_hl(),
         ' ',
         self.status,
-      }
-    elseif self.options.icon_right then
+      })
+    elseif self.options.icon_alignment == 'right' then
       self.status = table.concat({ self.status, icon }, ' ')
     else
       self.status = table.concat({ icon, self.status }, ' ')

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -113,7 +113,6 @@ function M:apply_icon()
   local icon = self.options.icon
   if self.options.icons_enabled and icon then
     if type(icon) == 'table' then
-      self.options.icon.align = icon.align
       icon = icon[1]
     end
     if self.options.icon_color_highlight and type(self.options.icon) == 'table' and self.options.icon.align == 'right' then

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -113,10 +113,10 @@ function M:apply_icon()
   local icon = self.options.icon
   if self.options.icons_enabled and icon then
     if type(icon) == 'table' then
-      self.options.icon_alignment = icon.align
+      self.options.icon.align = icon.align
       icon = icon[1]
     end
-    if self.options.icon_color_highlight and self.options.icon_alignment == 'right' then
+    if self.options.icon_color_highlight and type(self.options.icon) == 'table' and self.options.icon.align == 'right' then
       self.status = table.concat {
         self.status,
         ' ',

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -123,6 +123,8 @@ function M:apply_icon()
         ' ',
         self.status,
       }
+    elseif self.options.icon_right then
+      self.status = table.concat({ self.status, icon }, ' ')
     else
       self.status = table.concat({ icon, self.status }, ' ')
     end

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -76,9 +76,7 @@ function M:apply_padding()
       -- When component has changed the highlight at begining
       -- we will add the padding after the highlight
       local pre_highlight = vim.fn.matchlist(self.status, [[\(%#.\{-\}#\)]])[2]
-      self.status = pre_highlight
-        .. string.rep(' ', l_padding)
-        .. self.status:sub(#pre_highlight + 1, #self.status)
+      self.status = pre_highlight .. string.rep(' ', l_padding) .. self.status:sub(#pre_highlight + 1, #self.status)
     else
       self.status = string.rep(' ', l_padding) .. self.status
     end

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -61,6 +61,8 @@ function M:apply_icon()
 
   if self.options.icon_only then
     self.status = icon
+  elseif self.options.icon_right then
+    self.status = self.status .. ' ' .. icon
   else
     self.status = icon .. ' ' .. self.status
   end

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -61,7 +61,7 @@ function M:apply_icon()
 
   if self.options.icon_only then
     self.status = icon
-  elseif self.options.icon_alignment == 'right' then
+  elseif type(self.options.icon) == 'table' and self.options.icon.align == 'right' then
     self.status = self.status .. ' ' .. icon
   else
     self.status = icon .. ' ' .. self.status

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -61,7 +61,7 @@ function M:apply_icon()
 
   if self.options.icon_only then
     self.status = icon
-  elseif self.options.icon_right then
+  elseif self.options.icon_alignment == 'right' then
     self.status = self.status .. ' ' .. icon
   else
     self.status = icon .. ' ' .. self.status

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -361,6 +361,24 @@ describe('Filetype component', function()
     assert_component('filetype', opts, '*')
     package.loaded['nvim-web-devicons'] = nil
   end)
+
+  it('displays right aligned icon when icon.align is "right"', function()
+    package.loaded['nvim-web-devicons'] = {
+      get_icon = function()
+        return '*', 'test_highlight_group'
+      end,
+    }
+
+    local opts = build_component_opts {
+      component_separators = { left = '', right = '' },
+      padding = 0,
+      colored = false,
+      icon_only = false,
+      icon = { align = 'right' }
+    }
+    assert_component('filetype', opts, 'lua *')
+    package.loaded['nvim-web-devicons'] = nil
+  end)
 end)
 
 describe('Hostname component', function()


### PR DESCRIPTION
I was about to open an issue for this but figured it seemed easy enough.
Here is the issue template I was going to provide.

Set: `icon_right = true`

### Requested feature

Allow component icons to be displayed on both the left and right side.

![gimp-2 10_fO1cGKEU7J](https://user-images.githubusercontent.com/36192863/165288945-3527d022-4222-4f62-8e7c-112ab3d5c08c.gif)

### Motivation

Seems fairly simple and I like the look.