### PR TITLE
PoC tagline devicons and modifiability/modified markers

### DIFF
--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -211,8 +211,8 @@ end
 ---Get stl formated hl group for hl_token
 ---@param hl_token table indentifier received from create_hl or create_component_highlight_group
 ---@return string stl formated hl group for hl_token
-function M:format_hl(hl_token)
-  return highlight.component_format_highlight(hl_token)
+function M:format_hl(hl_token, is_focused)
+  return highlight.component_format_highlight(hl_token, is_focused)
 end
 
 -- luacheck: push no unused args

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -34,10 +34,9 @@ function Tab:label()
   end
 
   local file = modules.utils.stl_escape(self.f_name)
-  local buftype = vim.fn.getbufvar(self.bufnr, '&buftype')
-  if buftype == 'help' then
+  if self.buftype == 'help' then
     return 'help:' .. vim.fn.fnamemodify(file, ':t:r')
-  elseif buftype == 'terminal' then
+  elseif self.buftype == 'terminal' then
     local match = string.match(vim.split(file, ' ')[1], 'term:.*:(%a+)')
     return match ~= nil and match or vim.fn.fnamemodify(vim.env.SHELL, ':t')
   elseif vim.fn.isdirectory(file) == 1 then
@@ -55,6 +54,8 @@ function Tab:render()
   local winnr = vim.fn.tabpagewinnr(self.tabnr)
 
   self.bufnr = buflist[winnr]
+  self.buftype = vim.fn.getbufvar(self.bufnr, '&buftype')
+  self.filetype = vim.fn.getbufvar(self.bufnr, '&filetype')
   self.f_name = vim.api.nvim_buf_get_name(self.bufnr)
   self.f_extension = vim.fn.fnamemodify(self.f_name, ':e')
 

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -304,16 +304,17 @@ end
 function M.create_component_highlight_group(color, highlight_tag, options, apply_no_default)
   local section = options.self.section
   local tag_id = 0
+  local highlight_tag_counted = highlight_tag
   while
-    M.highlight_exists(table.concat({ 'lualine', section, highlight_tag }, '_'))
-    or (section and M.highlight_exists(table.concat({ 'lualine', section, highlight_tag, 'normal' }, '_')))
+    M.highlight_exists(table.concat({ 'lualine', section, highlight_tag_counted }, '_'))
+    or (section and M.highlight_exists(table.concat({ 'lualine', section, highlight_tag_counted, 'normal' }, '_')))
   do
-    highlight_tag = highlight_tag .. '_' .. tostring(tag_id)
+    highlight_tag_counted = highlight_tag .. '_' .. tostring(tag_id)
     tag_id = tag_id + 1
   end
 
   if type(color) == 'string' then
-    local highlight_group_name = table.concat({ 'lualine', section, highlight_tag }, '_')
+    local highlight_group_name = table.concat({ 'lualine', section, highlight_tag_counted }, '_')
     M.highlight(highlight_group_name, nil, nil, nil, color) -- l8nk to group
     return {
       name = highlight_group_name,
@@ -329,7 +330,7 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
   if type(color) ~= 'function' and (apply_no_default or (color.bg and color.fg)) then
     -- When bg and fg are both present we donn't need to set highlighs for
     -- each mode as they will surely look the same. So we can work without options
-    local highlight_group_name = table.concat({ 'lualine', section, highlight_tag }, '_')
+    local highlight_group_name = table.concat({ 'lualine', section, highlight_tag_counted }, '_')
     M.highlight(highlight_group_name, color.fg, color.bg, color.gui, nil)
     return {
       name = highlight_group_name,
@@ -351,7 +352,7 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
     'inactive',
   }
   for _, mode in ipairs(modes) do
-    local hl_name = table.concat({ 'lualine', section, highlight_tag, mode }, '_')
+    local hl_name = table.concat({ 'lualine', section, highlight_tag_counted, mode }, '_')
     local cl = color
     if type(color) == 'function' then
       cl = color { section = section } or {}
@@ -364,7 +365,7 @@ function M.create_component_highlight_group(color, highlight_tag, options, apply
     M.highlight(hl_name, cl.fg, cl.bg, cl.gui, cl.link)
   end
   return {
-    name = table.concat({ 'lualine', section, highlight_tag }, '_'),
+    name = table.concat({ 'lualine', section, highlight_tag_counted }, '_'),
     fn = type(color) == 'function' and color,
     no_mode = false,
     link = false,


### PR DESCRIPTION
## Summary

_Obligatory request to not judge the code too harshly - first time dealing with lua in a serious manner. I'd spent more time figuring out patterns and execution flow than beautifying the code._

This is an attempt to implement the behaviour I'd gotten attached to with lualine back in the day - devicons, modification and modifiability markers in the tabaline, derived from currently active buffers on the tab pages.

<img width="1567" alt="image" src="https://user-images.githubusercontent.com/314453/167063148-03c86a97-1f62-4379-a35f-4572b3db7ee7.png">

```lua
    tabline = {
      lualine_a = {
        {
          'tabs',
          max_length = vim.o.columns,
          mode = 2,
          icons_enabled = true,
          modification_icons_enabled = true,
          icon = {
            align = 'right',
            use_default = true
          },
        }
      },
    },
```

Might I request assistance from someone who's experienced with lua in order to get this to a mergeable state?

## Caveats

- I'd taken a shortcut and made tab component extend filetype one in order to avoid introducing a competing standard No. 42. This probably should instead be replaced by extraction of `apply_icon` function into a utility module to be reused by specific components as they see fit.
- While fumbling around with highlight groups generation, I discovered a bug in `highlight.create_component_highlight_group` which I'd fixed in a separate commit so that it can be pulled in if need be. I don't think the bug surfaces often (it took some very bad code to trigger it), but it can lead to attempts to generate highlight groups with names longer than allowed.
- I'd implemented a simple icon lookup fallback, which might mostly resolve https://github.com/nvim-lualine/lualine.nvim/issues/578. It doesn't resolve cases with ruby file having its buffer's filetype set to something else, but that aligns with recommended behaviour in https://github.com/kyazdani42/nvim-web-devicons/pull/125. Again, a separate commit, although it's unlikely to be cherry-pickable.