### PR TITLE
Fix filename shortening

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -63,7 +63,7 @@ M.update_status = function(self)
 
     local path_separator = package.config:sub(1, 1)
     for _ = 0, count(data, path_separator) do
-      if windwidth <= 84 or #data > estimated_space_available then
+      if #data > estimated_space_available then
         data = shorten_path(data, path_separator)
       end
     end


### PR DESCRIPTION
This was debugged with these changes:
```lua
  if self.options.shorting_target ~= 0 then
    local windwidth = self.options.globalstatus and vim.go.columns or vim.fn.winwidth(0)
    local estimated_space_available = windwidth - self.options.shorting_target
    local path_separator = package.config:sub(1, 1)

    local full_width = #data;
    for _ = 0, count(data, path_separator) do
      if #data > estimated_space_available then
        vim.notify(
          [[original width: ]] .. full_width ..
          [[, data length: ]] .. #data ..
          [[, data: ]] .. data ..
          [[, available ]] .. estimated_space_available)

        data = shorten_path(data, path_separator)
      end
    end
  end
```

![image](https://user-images.githubusercontent.com/199018/168484332-0f767066-2396-40e2-8b4d-015eb83742db.png)
![image](https://user-images.githubusercontent.com/199018/168484385-28864ebb-aa69-45da-ac89-e6de5f65a094.png)
![image](https://user-images.githubusercontent.com/199018/168484401-f5938651-b82e-49fe-87bf-b0d4e8f9be0e.png)
![image](https://user-images.githubusercontent.com/199018/168484439-c0ed02d8-7be8-4ffb-9ae0-947524cbdb39.png)


<details><summary>config tested with</summary>

```lua
  use {
    'nvim-lualine/lualine.nvim',
    config = function ()

      require('lualine').setup {

        options = {
          theme = 'dracula',
        },
        extensions = { 'fzf', 'nvim-tree' },

        sections = {
          lualine_a = { {'mode', upper = true} },
          -- lualine_b = { {'branch', icon = ''} },
          lualine_b = { {'diff'} },
          lualine_c = { {'filename', file_status = false, path = 1 } },
          lualine_x = { 'filetype' },
          lualine_y = { 'progress' },
          lualine_z = { 'location'  },
        },
        inactive_sections = {
          lualine_a = {  },
          -- lualine_b = {  },
          lualine_b = { {'branch', icon = ''} },
          lualine_c = { {'filename', file_status = true, path = 1 } },
          lualine_x = {  },
          lualine_y = {  },
          lualine_z = {  }
        },
      }

    end
  }
```

</details>
