### PR TITLE
feat: Add an extension for man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ extensions = {'quickfix'}
 - fern
 - fugitive
 - fzf
+- man
 - nerdtree
 - neo-tree
 - nvim-tree

--- a/lua/lualine/extensions/man.lua
+++ b/lua/lualine/extensions/man.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+M.sections = {
+  lualine_a = {
+    function()
+      return 'MAN'
+    end,
+  },
+  lualine_b = { { 'filename', file_status = false } },
+  lualine_y = { 'progress' },
+  lualine_z = { 'location' },
+}
+
+M.filetypes = { 'man' }
+
+return M


### PR DESCRIPTION
This will be used with Neovim's built-in `:Man` command and `man` filetype.
