### PR TITLE
Add option to sort/filter buffers by :ls flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ sections = {
       show_filename_only = true,   -- Shows shortened relative path when set to false.
       hide_filename_extension = false,   -- Hide filename extension when set to true.
       show_modified_status = true, -- Shows indicator when the buffer is modified.
+      sort_last_accessed = false, -- Sorts buffers by the time they were last accessed when set to true.
 
       mode = 0, -- 0: Shows buffer name
                 -- 1: Shows buffer index

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ sections = {
       show_filename_only = true,   -- Shows shortened relative path when set to false.
       hide_filename_extension = false,   -- Hide filename extension when set to true.
       show_modified_status = true, -- Shows indicator when the buffer is modified.
-      sort_last_accessed = false, -- Sorts buffers by the time they were last accessed when set to true.
+      ls_flags = '', -- Flags to pass to :ls (sorts/filters buffers, e.g. 't' sorts buffers by "time last used" - check :help :ls for valid flags)
 
       mode = 0, -- 0: Shows buffer name
                 -- 1: Shows buffer index

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -9,6 +9,7 @@ local default_options = {
   show_filename_only = true,
   hide_filename_extension = false,
   show_modified_status = true,
+  sort_last_accessed = false,
   mode = 0,
   max_length = 0,
   filetype_names = {
@@ -76,18 +77,29 @@ end
 function M:buffers()
   local buffers = {}
   M.bufpos2nr = {}
-  local blist = vim.split(vim.api.nvim_exec("ls t", true), "\n")
-  for i = 1, #blist do
-    -- get buffer number
-    local current = vim.trim(blist[i])
-    local bstring = current:gsub("^(%d+).*", "%1")
-    local b = tonumber(bstring)
-    if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
-      buffers[#buffers + 1] = self:new_buffer(b, b)
-      M.bufpos2nr[#buffers] = b
-    end
+  -- check sorting
+  if self.options.sort_last_accessed then
+      -- sort by last accessed
+      local blist = vim.split(vim.api.nvim_exec("ls t", true), "\n")
+      for i = 1, #blist do
+        -- get buffer number
+        local current = vim.trim(blist[i])
+        local bstring = current:gsub("^(%d+).*", "%1")
+        local b = tonumber(bstring)
+        if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
+          buffers[#buffers + 1] = self:new_buffer(b, b)
+          M.bufpos2nr[#buffers] = b
+        end
+      end
+  else
+      -- sort by buffer nr
+      for b = 1, vim.fn.bufnr('$') do
+        if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
+          buffers[#buffers + 1] = self:new_buffer(b, #buffers + 1)
+          M.bufpos2nr[#buffers] = b
+        end
+      end
   end
-
   return buffers
 end
 

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -76,7 +76,12 @@ end
 function M:buffers()
   local buffers = {}
   M.bufpos2nr = {}
-  for b = 1, vim.fn.bufnr('$') do
+  local blist = vim.split(vim.api.nvim_exec("ls t", true), "\n")
+  for i = 1, #blist do
+    -- get buffer number
+    local current = vim.trim(blist[i])
+    local bstring = current:gsub("^(%d+).*", "%1")
+    local b = tonumber(bstring)
     if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
       buffers[#buffers + 1] = self:new_buffer(b, #buffers + 1)
       M.bufpos2nr[#buffers] = b

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -9,7 +9,7 @@ local default_options = {
   show_filename_only = true,
   hide_filename_extension = false,
   show_modified_status = true,
-  sort_last_accessed = false,
+  ls_flags = '',
   mode = 0,
   max_length = 0,
   filetype_names = {
@@ -78,9 +78,9 @@ function M:buffers()
   local buffers = {}
   M.bufpos2nr = {}
   -- check sorting
-  if self.options.sort_last_accessed then
-      -- sort by last accessed
-      local blist = vim.split(vim.api.nvim_exec("ls t", true), "\n")
+  if self.options.ls_flags ~= '' then
+      -- sort by (:ls ...)
+      local blist = vim.split(vim.api.nvim_exec("ls " .. self.options.ls_flags, true), "\n")
       for i = 1, #blist do
         -- get buffer number
         local current = vim.trim(blist[i])

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -83,7 +83,7 @@ function M:buffers()
     local bstring = current:gsub("^(%d+).*", "%1")
     local b = tonumber(bstring)
     if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
-      buffers[#buffers + 1] = self:new_buffer(b, #buffers + 1)
+      buffers[#buffers + 1] = self:new_buffer(b, b)
       M.bufpos2nr[#buffers] = b
     end
   end


### PR DESCRIPTION
Buffers can be sorted according to the time they were last accessed (as printed by `:ls t`)