### PR TITLE
feat: refresh lualine based on timer + winbar support. (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,10 @@ require('lualine').setup {
     theme = 'auto',
     component_separators = { left = '', right = ''},
     section_separators = { left = '', right = ''},
-    disabled_filetypes = {},
+    disabled_filetypes = {
+      statusline = {},
+      winbar = {},
+    },
     always_divide_middle = true,
     globalstatus = false,
     refresh = {
@@ -343,7 +346,10 @@ options = {
   theme = 'auto', -- lualine theme
   component_separators = { left = '', right = '' },
   section_separators = { left = '', right = '' },
-  disabled_filetypes = {},     -- Filetypes to disable lualine for.
+  disabled_filetypes = {     -- Filetypes to disable lualine for.
+      statusline = {},       -- only ignores the ft for statusline.
+      winbar = {},           -- only ignores the ft for winbar.
+  },
 
   always_divide_middle = true, -- When set to true, left sections i.e. 'a','b' and 'c'
                                -- can't take over the entire statusline even

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ require('lualine').setup {
     disabled_filetypes = {},
     always_divide_middle = true,
     globalstatus = false,
+    refresh = {
+      statusline = 1000,
+      tabline = 1000,
+      winbar = 1000,
+    }
   },
   sections = {
     lualine_a = {'mode'},
@@ -142,6 +147,8 @@ require('lualine').setup {
     lualine_z = {}
   },
   tabline = {},
+  winbar = {},
+  inactive_winbar = {},
   extensions = {}
 }
 ```
@@ -337,12 +344,24 @@ options = {
   component_separators = { left = '', right = '' },
   section_separators = { left = '', right = '' },
   disabled_filetypes = {},     -- Filetypes to disable lualine for.
+
   always_divide_middle = true, -- When set to true, left sections i.e. 'a','b' and 'c'
                                -- can't take over the entire statusline even
                                -- if neither of 'x', 'y' or 'z' are present.
+
   globalstatus = false,        -- enable global statusline (have a single statusline
                                -- at bottom of neovim instead of one for  every window).
                                -- This feature is only available in neovim 0.7 and higher.
+
+  refresh = {                  -- sets how often lualine should refreash it's contents (in ms)
+    statusline = 1000,         -- The refresh option sets minimum time that lualine tries
+    tabline = 1000,            -- to maintain between refresh. It's not guarantied if situation
+    winbar = 1000              -- arises that lualine needs to refresh itself before this time
+                               -- it'll do it.
+
+                               -- Also you can force lualine's refresh by calling refresh function
+                               -- like require('lualine').refresh()
+  }
 }
 ```
 
@@ -688,6 +707,34 @@ tabline = {
   lualine_z = {'tabs'}
 }
 ```
+
+### Winbar
+From neovim-0.8 you can customize your winbar with lualine.
+Winbar configuration is similar to statusline.
+```lua
+winbar = {
+  lualine_a = {},
+  lualine_b = {},
+  lualine_c = {'filename'},
+  lualine_x = {},
+  lualine_y = {},
+  lualine_z = {}
+}
+
+inactive_winbar = {
+  lualine_a = {},
+  lualine_b = {},
+  lualine_c = {'filename'},
+  lualine_x = {},
+  lualine_y = {},
+  lualine_z = {}
+}
+```
+Just like statusline you can separately specify winbar for active and inactive
+windows. Any lualine component can be placed in winbar. All kinds of custom
+components supported in statusline are also suported for winbar too. In general
+You can treat winbar as another lualine statusline that just appears on top
+of windows instead of at bottom.
 
 #### Buffers
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -145,7 +145,7 @@ end
 ---      component objects
 ---@param is_focused boolean : whether being evaluated for focused window or not
 ---@return string statusline string
-local statusline = modules.utils.retry_call_wrap(function(sections, is_focused)
+local statusline = modules.utils.retry_call_wrap(function(sections, is_focused, is_winbar)
   -- The sequence sections should maintain [SECTION_SEQUENCE]
   local section_sequence = { 'a', 'b', 'c', 'x', 'y', 'z' }
   local status = {}
@@ -172,7 +172,7 @@ local statusline = modules.utils.retry_call_wrap(function(sections, is_focused)
       end
     end
   end
-  if applied_midsection_divider == false and config.options.always_divide_middle ~= false then
+  if applied_midsection_divider == false and config.options.always_divide_middle ~= false and not is_winbar then
     -- When non of section x,y,z is present
     table.insert(status, modules.highlight.format_highlight('c', is_focused) .. '%=')
   end
@@ -306,15 +306,15 @@ local function winbar_dispatch(focused)
   local extension_sections = get_extension_sections(current_ft, is_focused)
   if is_focused then
     if extension_sections ~= nil then
-      retval = statusline(extension_sections, is_focused)
+      retval = statusline(extension_sections, is_focused, true)
     else
-      retval = statusline(config.winbar, is_focused)
+      retval = statusline(config.winbar, is_focused, true)
     end
   else
     if extension_sections ~= nil then
-      retval = statusline(extension_sections, is_focused)
+      retval = statusline(extension_sections, is_focused, true)
     else
-      retval = statusline(config.inactive_winbar, is_focused)
+      retval = statusline(config.inactive_winbar, is_focused, true)
     end
   end
   return retval

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -272,11 +272,10 @@ local function status_dispatch(sec_name)
     local retval
     local current_ft = vim.bo.filetype
     local is_focused = focused ~= nil and focused or modules.utils.is_focused()
-    for _, ft in pairs(config.options.disabled_filetypes) do
+    if vim.tbl_contains(config.options.disabled_filetypes[(sec_name == 'sections' and 'statusline' or sec_name)],
+                        current_ft) then
       -- disable on specific filetypes
-      if ft == current_ft then
-        return ''
-      end
+      return ''
     end
     local extension_sections = get_extension_sections(current_ft, is_focused, sec_name)
     if extension_sections ~= nil then

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -16,6 +16,11 @@ local timers = {
   wb_timer = vim.loop.new_timer(),
 }
 
+-- The events on which lualine redraws itself
+local default_refresh_events = 'WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized'
+if vim.fn.has('nvim-0.7') == 1 then -- utilize ModeChanged event introduced in 0.7
+  default_refresh_events = default_refresh_events..',ModeChanged'
+end
 -- Helper for apply_transitional_separators()
 --- finds first applied highlight group after str_checked in status
 ---@param status string : unprocessed statusline string
@@ -367,7 +372,7 @@ local function set_tabline()
                          modules.utils.timer_call(timers.stl_timer, 'lualine_tal_refresh', function ()
                           refresh({kind='tabpage', place={'tabline'}})
                          end, 3, "lualine: Failed to refresh tabline"))
-    modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
+    modules.utils.define_autocmd(default_refresh_events,
                                  '*', "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['tabline']})",
                                  'lualine_tal_refresh')
     vim.go.showtabline = 2
@@ -389,7 +394,7 @@ local function set_statusline()
                            modules.utils.timer_call(timers.stl_timer, 'lualine_stl_refresh', function ()
                             refresh({kind='window', place={'statusline'}})
                            end, 3, "lualine: Failed to refresh statusline"))
-      modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
+      modules.utils.define_autocmd(default_refresh_events,
                                  '*', "call v:lua.require'lualine'.refresh({'kind': 'window', 'place': ['statusline']})",
                                  'lualine_stl_refresh')
     else
@@ -397,7 +402,7 @@ local function set_statusline()
                            modules.utils.timer_call(timers.stl_timer, 'lualine_stl_refresh', function ()
                             refresh({kind='tabpage', place={'statusline'}})
                            end, 3, "lualine: Failed to refresh statusline"))
-      modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
+      modules.utils.define_autocmd(default_refresh_events,
                                  '*', "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['statusline']})",
                                  'lualine_stl_refresh')
     end
@@ -421,7 +426,7 @@ local function set_winbar()
                          modules.utils.timer_call(timers.stl_timer, 'lualine_wb_refresh', function ()
                           refresh({kind='tabpage', place={'winbar'}})
                          end, 3, "lualine: Failed to refresh winbar"))
-    modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
+    modules.utils.define_autocmd(default_refresh_events,
                                '*', "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['winbar']})",
                                'lualine_wb_refresh')
   elseif vim.fn.has('nvim-0.8') == 1 then

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -381,6 +381,7 @@ local function set_statusline()
                                  '*', "call v:lua.require'lualine'.refresh({'kind': 'window', 'place': ['statusline']})",
                                  'lualine_stl_refresh')
     else
+      modules.nvim_opts.set('laststatus', 2, {global=true})
       vim.loop.timer_start(timers.stl_timer, 0, config.options.refresh.statusline,
                            modules.utils.timer_call(timers.stl_timer, 'lualine_stl_refresh', function ()
                             refresh({kind='tabpage', place={'statusline'}})

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -381,15 +381,23 @@ local function set_statusline()
   vim.loop.timer_stop(timers.stl_timer)
   vim.cmd([[augroup lualine_stl_refresh | exe "autocmd!" | augroup END]])
   if next(config.sections) ~= nil or next(config.inactive_sections) ~= nil then
-    vim.loop.timer_start(timers.stl_timer, 0, config.options.refresh.statusline,
-                         modules.utils.timer_call(timers.stl_timer, 'lualine_stl_refresh', function ()
-                          refresh({kind='tabpage', place={'statusline'}})
-                         end, 3, "lualine: Failed to refresh statusline"))
-    modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
-                               '*', "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['statusline']})",
-                               'lualine_stl_refresh')
     if config.options.globalstatus then
       vim.go.laststatus = 3
+      vim.loop.timer_start(timers.stl_timer, 0, config.options.refresh.statusline,
+                           modules.utils.timer_call(timers.stl_timer, 'lualine_stl_refresh', function ()
+                            refresh({kind='window', place={'statusline'}})
+                           end, 3, "lualine: Failed to refresh statusline"))
+      modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
+                                 '*', "call v:lua.require'lualine'.refresh({'kind': 'window', 'place': ['statusline']})",
+                                 'lualine_stl_refresh')
+    else
+      vim.loop.timer_start(timers.stl_timer, 0, config.options.refresh.statusline,
+                           modules.utils.timer_call(timers.stl_timer, 'lualine_stl_refresh', function ()
+                            refresh({kind='tabpage', place={'statusline'}})
+                           end, 3, "lualine: Failed to refresh statusline"))
+      modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
+                                 '*', "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['statusline']})",
+                                 'lualine_stl_refresh')
     end
   else
     vim.go.statusline = ''

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -336,7 +336,6 @@ end
 local function set_statusline()
   vim.loop.timer_stop(timers.stl_timer)
   if next(config.sections) ~= nil or next(config.inactive_sections) ~= nil then
-    vim.cmd("autocmd lualine VimResized * call v:lua.require'lualine'.refresh()")
     vim.loop.timer_start(timers.stl_timer, 0, config.options.refresh.statusline, refresh)
     if config.options.globalstatus then
       vim.go.laststatus = 3
@@ -365,6 +364,8 @@ local function setup(user_config)
   end
   config = modules.config_module.apply_configuration(user_config)
   vim.cmd([[augroup lualine | exe "autocmd!" | augroup END]])
+  modules.utils.define_autocmd('VimResized,WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost',
+                               '*', "call v:lua.require'lualine'.refresh()")
   setup_theme()
   -- load components & extensions
   modules.loader.load_all(config)

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -332,7 +332,7 @@ local refresh = function(opts)
   end
   local wins = {}
   local old_actual_curwin = vim.g.actual_curwin
-  vim.g.actual_curwin = tostring(vim.api.nvim_get_current_win())
+  vim.g.actual_curwin = vim.api.nvim_get_current_win()
   -- gather which windows needs update
   if opts.kind == 'all' then
     if vim.tbl_contains(opts.place, 'statusline')
@@ -372,6 +372,15 @@ local refresh = function(opts)
                     vim.api.nvim_win_call(vim.api.nvim_get_current_win(), tabline),
                     {global=true})
   end
+
+  -- call redraw
+  if vim.tbl_contains(opts.place, 'statusline')
+    or vim.tbl_contains(opts.place, 'winbar') then
+    vim.cmd('redrawstatus')
+  elseif vim.tbl_contains(opts.place, 'tabline') then
+    vim.cmd('redrawtabline')
+  end
+
   vim.g.actual_curwin = old_actual_curwin
 end
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -335,12 +335,16 @@ local refresh = function(opts)
   if opts.kind == 'all' then
     if vim.tbl_contains(opts.place, 'statusline')
       or vim.tbl_contains(opts.place, 'winbar') then
-      wins = vim.api.nvim_list_wins()
+      wins = vim.tbl_filter(function (win)
+        return vim.fn.win_gettype(win) ~= 'popup'
+      end, vim.api.nvim_list_wins())
     end
   elseif opts.kind == 'tabpage' then
     if vim.tbl_contains(opts.place, 'statusline')
       or vim.tbl_contains(opts.place, 'winbar') then
-      wins = vim.api.nvim_tabpage_list_wins(0)
+      wins = vim.tbl_filter(function (win)
+        return vim.fn.win_gettype(win) ~= 'popup'
+      end, vim.api.nvim_tabpage_list_wins(0))
     end
   elseif opts.kind == 'window' then
     wins = {vim.api.nvim_get_current_win()}

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -347,7 +347,9 @@ local refresh = function(opts)
   end
   if vim.tbl_contains(opts.place, 'winbar') then
     for _, win in ipairs(wins) do
-      vim.api.nvim_win_set_option(win, 'wbr', vim.api.nvim_win_call(win, winbar_dispatch))
+      if vim.api.nvim_win_get_height(win) > 1 then
+        vim.api.nvim_win_set_option(win, 'wbr', vim.api.nvim_win_call(win, winbar_dispatch))
+      end
     end
   end
   if vim.tbl_contains(opts.place, 'tabline') then

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -422,7 +422,7 @@ local function set_winbar()
     modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
                                '*', "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['winbar']})",
                                'lualine_wb_refresh')
-  else
+  elseif vim.fn.has('nvim-0.8') == 1 then
     vim.go.winbar = ''
     for _, win in ipairs(vim.api.nvim_list_wins()) do
       vim.api.nvim_win_set_option(win, 'winbar', '')

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -401,6 +401,9 @@ local function set_statusline()
     end
   else
     vim.go.statusline = ''
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      vim.api.nvim_win_set_option(win, 'stl', '')
+    end
     if config.options.globalstatus then
       vim.go.laststatus = 2
     end
@@ -419,6 +422,11 @@ local function set_winbar()
     modules.utils.define_autocmd('WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized',
                                '*', "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['winbar']})",
                                'lualine_wb_refresh')
+  else
+    vim.go.winbar = ''
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      vim.api.nvim_win_set_option(win, 'winbar', '')
+    end
   end
 end
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -288,7 +288,20 @@ local function status_dispatch(sec_name)
   end
 end
 
-local refresh = function(opts)
+---@alias LualineRefreshOptsKind
+---| 'all'
+---| 'tabpage'
+---| 'window'
+---@alias LualineRefreshOptsPlace
+---| 'statusline'
+---| 'tabline'
+---| 'winbar'
+---@class LualineRefreshOpts
+---@field kind LualineRefreshOptsKind
+---@field place LualineRefreshOptsPlace[]
+--- Refresh contents of lualine
+---@param opts LualineRefreshOpts
+local function refresh(opts)
   if opts == nil then
     opts = {kind = 'tabpage', place = {'statusline', 'winbar', 'tabline'}}
   end

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -59,6 +59,13 @@ end
 ---@param config_table table
 ---@return table copy of config
 local function apply_configuration(config_table)
+  if vim.fn.has('nvim-0.8') == 0 and (config_table.winbar or config_table.inactive_winbar) then
+    modules.utils_notices.add_notice(
+      '### winbar\nSorry `winbar can only be used in neovim 0.8 or higher.\n'
+    )
+    config_table.winbar = nil
+    config_table.inactive_winbar = nil
+  end
   if not config_table then
     return utils.deepcopy(config)
   end

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -15,6 +15,11 @@ local config = {
     disabled_filetypes = {},
     always_divide_middle = true,
     globalstatus = false,
+    refresh = {
+      statusline = 1000,
+      tabline = 1000,
+      winbar = 1000,
+    }
   },
   sections = {
     lualine_a = { 'mode' },

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -58,6 +58,24 @@ local function fix_separators(separators)
   return separators
 end
 
+---copy raw disabled_filetypes to inner statusline & winbar tables.
+---@param disabled_filetypes table
+---@return table
+local function fix_disabled_filetypes(disabled_filetypes)
+  if disabled_filetypes == nil then return end
+  if disabled_filetypes.statusline == nil then
+    disabled_filetypes.statusline = {}
+  end
+  if disabled_filetypes.winbar == nil then
+    disabled_filetypes.winbar = {}
+  end
+  for k, disabled_ft in ipairs(disabled_filetypes) do
+    table.insert(disabled_filetypes.statusline, disabled_ft)
+    table.insert(disabled_filetypes.winbar, disabled_ft)
+    disabled_filetypes[k] = nil
+  end
+  return disabled_filetypes
+end
 ---extends config based on config_table
 ---@param config_table table
 ---@return table copy of config
@@ -101,18 +119,7 @@ local function apply_configuration(config_table)
   end
   config.options.section_separators = fix_separators(config.options.section_separators)
   config.options.component_separators = fix_separators(config.options.component_separators)
-  -- copy raw disabled_filetypes to inner statusline & winbar tables.
-  if config.options.disabled_filetypes.statusline == nil then
-    config.options.disabled_filetypes.statusline = {}
-  end
-  if config.options.disabled_filetypes.winbar == nil then
-    config.options.disabled_filetypes.winbar = {}
-  end
-  for k, disabled_ft in ipairs(config.options.disabled_filetypes) do
-    table.insert(config.options.disabled_filetypes.statusline, disabled_ft)
-    table.insert(config.options.disabled_filetypes.winbar, disabled_ft)
-    config.options.disabled_filetypes[k] = nil
-  end
+  config.options.disabled_filetypes = fix_disabled_filetypes(config.options.disabled_filetypes)
   return utils.deepcopy(config)
 end
 

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -12,7 +12,10 @@ local config = {
     theme = 'auto',
     component_separators = { left = '', right = '' },
     section_separators = { left = '', right = '' },
-    disabled_filetypes = {},
+    disabled_filetypes = {
+      statusline = {},
+      winbar = {}
+    },
     always_divide_middle = true,
     globalstatus = vim.go.laststatus == 3,
     refresh = {
@@ -98,6 +101,18 @@ local function apply_configuration(config_table)
   end
   config.options.section_separators = fix_separators(config.options.section_separators)
   config.options.component_separators = fix_separators(config.options.component_separators)
+  -- copy raw disabled_filetypes to inner statusline & winbar tables.
+  if config.options.disabled_filetypes.statusline == nil then
+    config.options.disabled_filetypes.statusline = {}
+  end
+  if config.options.disabled_filetypes.winbar == nil then
+    config.options.disabled_filetypes.winbar = {}
+  end
+  for k, disabled_ft in ipairs(config.options.disabled_filetypes) do
+    table.insert(config.options.disabled_filetypes.statusline, disabled_ft)
+    table.insert(config.options.disabled_filetypes.winbar, disabled_ft)
+    config.options.disabled_filetypes[k] = nil
+  end
   return utils.deepcopy(config)
 end
 

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -38,6 +38,8 @@ local config = {
     lualine_z = {},
   },
   tabline = {},
+  winbar = {},
+  inactive_winbar = {},
   extensions = {},
 }
 
@@ -82,6 +84,8 @@ local function apply_configuration(config_table)
   parse_sections('sections')
   parse_sections('inactive_sections')
   parse_sections('tabline')
+  parse_sections('winbar')
+  parse_sections('inactive_winbar')
   if config_table.extensions then
     config.extensions = utils.deepcopy(config_table.extensions)
   end

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -14,7 +14,7 @@ local config = {
     section_separators = { left = '', right = '' },
     disabled_filetypes = {},
     always_divide_middle = true,
-    globalstatus = false,
+    globalstatus = vim.go.laststatus == 3,
     refresh = {
       statusline = 1000,
       tabline = 1000,

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -59,13 +59,6 @@ end
 ---@param config_table table
 ---@return table copy of config
 local function apply_configuration(config_table)
-  if vim.fn.has('nvim-0.8') == 0 and (config_table.winbar or config_table.inactive_winbar) then
-    modules.utils_notices.add_notice(
-      '### winbar\nSorry `winbar can only be used in neovim 0.8 or higher.\n'
-    )
-    config_table.winbar = nil
-    config_table.inactive_winbar = nil
-  end
   if not config_table then
     return utils.deepcopy(config)
   end
@@ -86,6 +79,13 @@ local function apply_configuration(config_table)
       '### Options.globalstatus\nSorry `globalstatus` option can only be used in neovim 0.7 or higher.\n'
     )
     config_table.options.globalstatus = false
+  end
+  if vim.fn.has('nvim-0.8') == 0 and (next(config_table.winbar or {}) or next(config_table.inactive_winbar or {})) then
+    modules.utils_notices.add_notice(
+      '### winbar\nSorry `winbar can only be used in neovim 0.8 or higher.\n'
+    )
+    config_table.winbar = {}
+    config_table.inactive_winbar = {}
   end
   parse_sections('options')
   parse_sections('sections')

--- a/lua/lualine/utils/loader.lua
+++ b/lua/lualine/utils/loader.lua
@@ -156,6 +156,8 @@ local function load_components(config)
   load_sections(config.sections, config.options)
   load_sections(config.inactive_sections, config.options)
   load_sections(config.tabline, config.options)
+  load_sections(config.winbar, config.options)
+  load_sections(config.inactive_winbar, config.options)
 end
 
 ---loads all the extensions

--- a/lua/lualine/utils/loader.lua
+++ b/lua/lualine/utils/loader.lua
@@ -154,11 +154,10 @@ end
 ---loads all the configs (active, inactive, tabline)
 ---@param config table user config
 local function load_components(config)
-  load_sections(config.sections, config.options)
-  load_sections(config.inactive_sections, config.options)
-  load_sections(config.tabline, config.options)
-  load_sections(config.winbar, config.options)
-  load_sections(config.inactive_winbar, config.options)
+  local sec_names = {'sections', 'inactive_sections', 'tabline', 'winbar', 'inactive_winbar'}
+  for _, section in ipairs(sec_names) do
+    load_sections(config[section], config.options)
+  end
 end
 
 ---loads all the extensions

--- a/lua/lualine/utils/loader.lua
+++ b/lua/lualine/utils/loader.lua
@@ -165,20 +165,12 @@ end
 ---@param config table user config
 local function load_extensions(config)
   local loaded_extensions = {}
+  local sec_names = {'sections', 'inactive_sections', 'winbar', 'inactive_winbar'}
   for _, extension in pairs(config.extensions) do
     if type(extension) == 'string' then
-      local ok, local_extension = pcall(require, 'lualine.extensions.' .. extension)
-      if ok then
-        local_extension = modules.utils.deepcopy(local_extension)
-        load_sections(local_extension.sections, config.options)
-        if local_extension.inactive_sections then
-          load_sections(local_extension.inactive_sections, config.options)
-        end
-        if type(local_extension.init) == 'function' then
-          local_extension.init()
-        end
-        table.insert(loaded_extensions, local_extension)
-      else
+      local ok
+      ok, extension = pcall(require, 'lualine.extensions.' .. extension)
+      if not ok then
         modules.notice.add_notice(string.format(
           [[
 ### Extensions
@@ -187,11 +179,13 @@ Extension named `%s` was not found . Check if spelling is correct.
           extension
         ))
       end
-    elseif type(extension) == 'table' then
+    end
+    if type(extension) == 'table' then
       local local_extension = modules.utils.deepcopy(extension)
-      load_sections(local_extension.sections, config.options)
-      if local_extension.inactive_sections then
-        load_sections(local_extension.inactive_sections, config.options)
+      for _, section in ipairs(sec_names) do
+        if local_extension[section] then
+          load_sections(local_extension[section], config.options)
+        end
       end
       if type(local_extension.init) == 'function' then
         local_extension.init()

--- a/lua/lualine/utils/loader.lua
+++ b/lua/lualine/utils/loader.lua
@@ -205,6 +205,7 @@ end
 ---@param config table user config
 local function load_all(config)
   require('lualine.component')._reset_component_id()
+  require('lualine.utils.nvim_opts').reset_cache()
   load_components(config)
   load_extensions(config)
 end

--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -85,6 +85,30 @@ function M.restore(name, opts)
   end
 end
 
+-- returns cache for the option name
+---@param name string
+---@param opts table|nil same as M.set
+function M.get_cache(name, opts)
+  if opts == nil or opts.global then
+    if options.global[name] ~= nil and options.global[name].prev ~= nil then
+      return options.global[name].prev
+    end
+  elseif opts.buffer then
+    if options.buffer[opts.buffer] ~= nil
+      and options.buffer[opts.buffer][name] ~= nil
+      and options.buffer[opts.buffer][name].prev ~= nil then
+      return options.buffer[opts.buffer][name].prev
+    end
+  elseif opts.window then
+    if options.window[opts.window] ~= nil
+      and options.window[opts.window][name] ~= nil
+      and options.window[opts.window][name].prev ~= nil then
+      return options.window[opts.window][name].prev
+    end
+  end
+
+end
+
 -- resets cache for options
 function M.reset_cache()
   options = {global={}, buffer={}, window={}}

--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -19,7 +19,11 @@ local options = {global={}, buffer={}, window={}}
 
 -- helper function for M.set
 local function set_opt(name, val, getter_fn, setter_fn, cache_tbl)
-  local cur = getter_fn(name)
+  -- before nvim 0.7 nvim_win_get_option... didn't return default value when
+  -- the option wasn't set instead threw error.
+  -- So we need pcall (probably just for test)
+  local ok, cur = pcall(getter_fn, name)
+  if not ok then cur = nil end
   if cur == val then return end
   if cache_tbl[name] == nil then cache_tbl[name] = {} end
   if cache_tbl[name].set ~= cur then

--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -15,6 +15,15 @@ local M = {}
 --     win2 = <1>
 --   }
 -- }
+---@class LualineNvimOptCacheOptStore
+---@field prev any
+---@field set any
+---@alias LualineNvimOptCacheOpt table<string, LualineNvimOptCacheOptStore>
+---@class LualineNvimOptCache
+---@field global LualineNvimOptCacheOpt[]
+---@field buffer table<number, LualineNvimOptCacheOpt[]>
+---@field window table<number, LualineNvimOptCacheOpt[]>
+---@type LualineNvimOptCache
 local options = {global={}, buffer={}, window={}}
 
 -- helper function for M.set

--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -1,0 +1,88 @@
+local M = {}
+
+-- keeps backup of options that we cahge so we can restore it.
+-- format:
+-- options {
+--   global = <1> {
+--     name = {prev, set}
+--   },
+--   buffer = {
+--     buf1 = <1>,
+--     buf2 = <1>
+--   },
+--   window = {
+--     win1 = <1>,
+--     win2 = <1>
+--   }
+-- }
+local options = {global={}, buffer={}, window={}}
+
+-- helper function for M.set
+local function set_opt(name, val, getter_fn, setter_fn, cache_tbl)
+  local cur = getter_fn(name)
+  if cache_tbl[name] == nil then cache_tbl[name] = {} end
+  if cache_tbl[name].set ~= cur then
+    cache_tbl[name].prev = cur
+  end
+  cache_tbl[name].set = val
+  setter_fn(name, val)
+end
+
+-- set a option value
+---@param name string
+---@param val any
+---@param opts table|nil when table can be {global=true | buffer = bufnr | window = winnr}
+---                      when nil it's treated as {global = true}
+function M.set(name, val, opts)
+  if opts == nil or opts.global then
+    set_opt(name, val, vim.api.nvim_get_option, vim.api.nvim_set_option, options.global)
+  elseif opts.buffer then
+    if options.buffer[opts.buffer] == nil then
+      options.buffer[opts.buffer] = {}
+    end
+    set_opt(name, val, function (nm)
+      return vim.api.nvim_buf_get_option(opts.buffer, nm)
+    end, function (nm, vl)
+      vim.api.nvim_buf_set_option(opts.buffer, nm, vl)
+    end, options.buffer[opts.buffer])
+  elseif opts.window then
+    if options.window[opts.window] == nil then
+      options.window[opts.window] = {}
+    end
+    set_opt(name, val, function (nm)
+      return vim.api.nvim_win_get_option(opts.window, nm)
+    end, function (nm, vl)
+      vim.api.nvim_win_set_option(opts.window, nm, vl)
+    end, options.window[opts.window])
+  end
+end
+
+-- resoters old value of option name
+---@param name string
+---@param opts table|nil same as M.set
+function M.restore(name, opts)
+  if opts == nil or opts.global then
+    if options.global[name] ~= nil and options.global[name].prev ~= nil then
+      vim.api.nvim_set_option(name, options.global[name].prev)
+    end
+  elseif opts.buffer then
+    if options.buffer[opts.buffer] ~= nil
+      and options.buffer[opts.buffer][name] ~= nil
+      and options.buffer[opts.buffer][name].prev ~= nil then
+      vim.api.nvim_buf_set_option(opts.buffer, name, options.buffer[opts.buffer][name].prev)
+    end
+  elseif opts.window then
+    if options.window[opts.window] ~= nil
+      and options.window[opts.window][name] ~= nil
+      and options.window[opts.window][name].prev ~= nil then
+      vim.api.nvim_win_set_option(opts.window, name, options.window[opts.window][name].prev)
+    end
+  end
+end
+
+-- resets cache for options
+function M.reset_cache()
+  options = {global={}, buffer={}, window={}}
+end
+
+return M

--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -20,6 +20,7 @@ local options = {global={}, buffer={}, window={}}
 -- helper function for M.set
 local function set_opt(name, val, getter_fn, setter_fn, cache_tbl)
   local cur = getter_fn(name)
+  if cur == val then return end
   if cache_tbl[name] == nil then cache_tbl[name] = {} end
   if cache_tbl[name].set ~= cur then
     cache_tbl[name].prev = cur

--- a/tests/spec/config_spec.lua
+++ b/tests/spec/config_spec.lua
@@ -86,12 +86,12 @@ describe('config parsing', function()
     describe('disabled filetypes', function()
       it('default', function()
         local config = config_module.apply_configuration {}
-        eq(config.options.disabled_filetypes, {})
+        eq(config.options.disabled_filetypes, {statusline={}, winbar={}})
       end)
       it('custom', function()
         local config = { options = { disabled_filetypes = { 'lua' } } }
         config = config_module.apply_configuration(config)
-        eq(config.options.disabled_filetypes, { 'lua' })
+        eq(config.options.disabled_filetypes, {statusline={'lua'}, winbar={'lua'}})
       end)
     end)
 

--- a/tests/spec/lualine_spec.lua
+++ b/tests/spec/lualine_spec.lua
@@ -18,6 +18,11 @@ describe('Lualine', function()
         disabled_filetypes = {},
         always_divide_middle = true,
         globalstatus = false,
+        refresh = {
+          statusline = 1000,
+          tabline = 1000,
+          winbar = 1000,
+        }
       },
       sections = {
         lualine_a = { 'mode' },

--- a/tests/spec/lualine_spec.lua
+++ b/tests/spec/lualine_spec.lua
@@ -53,6 +53,8 @@ describe('Lualine', function()
         lualine_z = {},
       },
       tabline = {},
+      winbar = {},
+      inactive_winbar = {},
       extensions = {},
     }
 

--- a/tests/spec/lualine_spec.lua
+++ b/tests/spec/lualine_spec.lua
@@ -15,7 +15,10 @@ describe('Lualine', function()
         theme = 'gruvbox',
         component_separators = { left = '', right = '' },
         section_separators = { left = '', right = '' },
-        disabled_filetypes = {},
+        disabled_filetypes = {
+          statusline = {},
+          winbar = {},
+        },
         always_divide_middle = true,
         globalstatus = false,
         refresh = {


### PR DESCRIPTION
### Needs testing

Try testing this branch and if you find any issue let me know in comment

### What it is
With this lualine will control it's own refresh instead of relying on nvim.

If we refresh this way we should be able to change out the statusline, winbar, tabline options and still be running . We should be able to address https://github.com/nvim-lualine/lualine.nvim/pull/689#issuecomment-1157194479 & #395 with this style of update.

### Major changes
-  lualine now refresh based on timer + some auto-commands.
- added `require('lualine').refresh` function to force refresh lualine . It can refresh all statusline, tabline, winbars or can granularly refresh specific statusline/tabline/winbar of specific windows see the code docs for more info.
-  winbar support. (originally form #689 by @diegodox)
- winbar support in extensions.
-  newly added options
    - options.refresh.statusline
    - options.refresh.tabline
    - options.refresh.winbar 
    -  options.disabled_filetypes.statusline
    -  options.disabled_filetypes.winbar
    -  winbar
    -  inactive_winbar
-  various bug fixes.


### known Issues/todos:
- ~~Refresh time is set to 1s . It seems when changing wins inactive & active stls don't switch immediately instead takes that 1s to update which is quite noticeable . Possible solutions: utilize autocommads to refresh on such events.~~
- ~~We need to handle errors in the refresh funcitnon so if we say fail to update 3 times in a row we should stop the timer~~.
- ~~looks like nvim wants to put winbars on floating windows too. but it might fail if there aren't enough room like telescopes prompt . that's an issue for us. wonder if we can determine if a win is float or not and skip floats 🤦‍♂️~~ (skiping winbar on winheight <= 1 & floating windows)
- ~~try merging statusline_dispatch and winbar_dispatch togather they have a lot of duplication~~
- ~~statusline doesn't seem to update regularly in cmdline mode~~
- ~~nvim-0,5 & 0.6 is broken with nvim_opts module . (may we should just have compat tags for older nvim version and be done with them . keeping support for them is getting annoying )~~
- ~~live update seems broken for gobalstatus & separators options.~~
- yes we have that intro disappearing due to redraw issue again.

closes #744 #692
supersedes #689