### PR TITLE
Added support for import.nvim as extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ extensions = {'quickfix'}
 - fern
 - fugitive
 - fzf
+- import
 - man
 - mundo
 - neo-tree

--- a/lua/lualine/extensions/import.lua
+++ b/lua/lualine/extensions/import.lua
@@ -1,0 +1,6 @@
+local M = {}
+
+M.sections = { lualine_a = {'filetype'}}
+M.filetypes = {'ImportManager'}
+
+return M


### PR DESCRIPTION
See title lol. 
I have added [`import.nvim`](https://github.com/miversen33/import.nvim/pull/6), but cannot merge it until the lualine extension has been accepted :)

Note: This extension includes an example of how to implement the [`on_click`](https://github.com/nvim-lualine/lualine.nvim/pull/742) functionality, I am unsure if that has been documented fully or if other plugins/extensions are currently using it.