### PR TITLE
fix: Remove base16-specific actions in "auto" theme

### DIFF
--- a/lua/lualine/themes/auto.lua
+++ b/lua/lualine/themes/auto.lua
@@ -5,11 +5,6 @@ local loader = require('lualine.utils.loader')
 
 local color_name = vim.g.colors_name
 if color_name then
-  -- All base16 colorschemes share the same theme
-  if 'base16' == color_name:sub(1, 6) then
-    color_name = 'base16'
-  end
-
   -- Check if there's a theme for current colorscheme
   -- If there is load that instead of generating a new one
   local ok, theme = pcall(loader.load_theme, color_name)


### PR DESCRIPTION
Closes #796.

The test suite seems broken:
```
Starting...Scheduling: tests//spec/config_spec.lua
Scheduling: tests//spec/component_spec.lua
Scheduling: tests//spec/utils_spec.lua
Scheduling: tests//spec/lualine_spec.lua
make: *** [test] Error 1
```
That's all I get.