### PR TITLE
fix component(filetype) proper icon based on filetype

### DIFF
--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -31,9 +31,7 @@ function M:apply_icon()
   local icon, icon_highlight_group
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if ok then
-    local f_name, f_extension = vim.fn.expand('%:t'), vim.fn.expand('%:e')
-    f_extension = f_extension ~= '' and f_extension or vim.bo.filetype
-    icon, icon_highlight_group = devicons.get_icon(f_name, f_extension)
+    icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
 
     if icon == nil and icon_highlight_group == nil then
       icon = ''

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -32,6 +32,9 @@ function M:apply_icon()
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if ok then
     icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
+    if icon == nil then
+      icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
+    end
 
     if icon == nil and icon_highlight_group == nil then
       icon = ''

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -424,6 +424,42 @@ describe('Filetype component', function()
     hl.create_component_highlight_group:revert()
     vim.fn.expand:revert()
   end)
+
+  it('uses filetype lookup when file has no extension', function()
+    stub(vim.fn, 'expand')
+    vim.fn.expand.on_call_with('%:t').returns('test')
+
+    local hl = require('lualine.highlight')
+    stub(hl, 'create_component_highlight_group')
+
+    local utils = require('lualine.utils.utils')
+    stub(utils, 'extract_highlight_colors')
+
+    local devicons = require('nvim-web-devicons')
+    stub(devicons, 'get_icon')
+    devicons.get_icon.on_call_with('test').returns(nil)
+    stub(devicons, 'get_icon_by_filetype')
+    devicons.get_icon_by_filetype.on_call_with('lua').returns('*', 'test_highlight_group')
+
+    local opts = build_component_opts {
+      component_separators = { left = '', right = '' },
+      padding = 0,
+      colored = false,
+      icon_only = false,
+    }
+    assert_component('filetype', opts, '* lua')
+    assert.stub(devicons.get_icon).was_called_with('test')
+    assert.stub(devicons.get_icon_by_filetype).was_called_with('lua')
+    assert.stub(utils.extract_highlight_colors).was_not_called()
+    assert.stub(hl.create_component_highlight_group).was_not_called()
+    assert.stub(vim.fn.expand).was_called_with('%:t')
+
+    devicons.get_icon_by_filetype:revert()
+    devicons.get_icon:revert()
+    utils.extract_highlight_colors:revert()
+    hl.create_component_highlight_group:revert()
+    vim.fn.expand:revert()
+  end)
 end)
 
 describe('Hostname component', function()

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -288,7 +288,6 @@ describe('Filetype component', function()
     vim.g.actual_curwin = tostring(vim.api.nvim_get_current_win())
     stub(vim.fn, 'expand')
     vim.fn.expand.on_call_with('%:t').returns('test.lua')
-    vim.fn.expand.on_call_with('%:e').returns('lua')
 
     local hl = require('lualine.highlight')
     stub(hl, 'create_component_highlight_group')
@@ -302,7 +301,7 @@ describe('Filetype component', function()
 
     local devicons = require('nvim-web-devicons')
     stub(devicons, 'get_icon')
-    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
+    devicons.get_icon.on_call_with('test.lua').returns('*', 'test_highlight_group')
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
@@ -312,7 +311,7 @@ describe('Filetype component', function()
       icon_only = false,
     }
     assert_component('filetype', opts, '%#MyCompHl_normal#*%#lualine_c_normal# lua%#lualine_c_normal#')
-    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
+    assert.stub(devicons.get_icon).was_called_with('test.lua')
     assert.stub(utils.extract_highlight_colors).was_called_with('test_highlight_group', 'fg')
     assert.stub(hl.create_component_highlight_group).was_called_with(
       { fg = '#000' },
@@ -321,7 +320,6 @@ describe('Filetype component', function()
       false
     )
     assert.stub(vim.fn.expand).was_called_with('%:t')
-    assert.stub(vim.fn.expand).was_called_with('%:e')
 
     devicons.get_icon:revert()
     utils.extract_highlight_colors:revert()
@@ -334,7 +332,6 @@ describe('Filetype component', function()
   it("doesn't color when colored is false", function()
     stub(vim.fn, 'expand')
     vim.fn.expand.on_call_with('%:t').returns('test.lua')
-    vim.fn.expand.on_call_with('%:e').returns('lua')
 
     local hl = require('lualine.highlight')
     stub(hl, 'create_component_highlight_group')
@@ -344,7 +341,7 @@ describe('Filetype component', function()
 
     local devicons = require('nvim-web-devicons')
     stub(devicons, 'get_icon')
-    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
+    devicons.get_icon.on_call_with('test.lua').returns('*', 'test_highlight_group')
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
@@ -352,11 +349,10 @@ describe('Filetype component', function()
       colored = false,
     }
     assert_component('filetype', opts, '* lua')
-    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
+    assert.stub(devicons.get_icon).was_called_with('test.lua')
     assert.stub(utils.extract_highlight_colors).was_not_called()
     assert.stub(hl.create_component_highlight_group).was_not_called()
     assert.stub(vim.fn.expand).was_called_with('%:t')
-    assert.stub(vim.fn.expand).was_called_with('%:e')
 
     devicons.get_icon:revert()
     utils.extract_highlight_colors:revert()
@@ -367,7 +363,6 @@ describe('Filetype component', function()
   it('displays only icon when icon_only is true', function()
     stub(vim.fn, 'expand')
     vim.fn.expand.on_call_with('%:t').returns('test.lua')
-    vim.fn.expand.on_call_with('%:e').returns('lua')
 
     local hl = require('lualine.highlight')
     stub(hl, 'create_component_highlight_group')
@@ -377,7 +372,7 @@ describe('Filetype component', function()
 
     local devicons = require('nvim-web-devicons')
     stub(devicons, 'get_icon')
-    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
+    devicons.get_icon.on_call_with('test.lua').returns('*', 'test_highlight_group')
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
@@ -386,11 +381,10 @@ describe('Filetype component', function()
       icon_only = true,
     }
     assert_component('filetype', opts, '*')
-    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
+    assert.stub(devicons.get_icon).was_called_with('test.lua')
     assert.stub(utils.extract_highlight_colors).was_not_called()
     assert.stub(hl.create_component_highlight_group).was_not_called()
     assert.stub(vim.fn.expand).was_called_with('%:t')
-    assert.stub(vim.fn.expand).was_called_with('%:e')
 
     devicons.get_icon:revert()
     utils.extract_highlight_colors:revert()
@@ -401,7 +395,6 @@ describe('Filetype component', function()
   it('displays right aligned icon when icon.align is "right"', function()
     stub(vim.fn, 'expand')
     vim.fn.expand.on_call_with('%:t').returns('test.lua')
-    vim.fn.expand.on_call_with('%:e').returns('lua')
 
     local hl = require('lualine.highlight')
     stub(hl, 'create_component_highlight_group')
@@ -411,7 +404,7 @@ describe('Filetype component', function()
 
     local devicons = require('nvim-web-devicons')
     stub(devicons, 'get_icon')
-    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
+    devicons.get_icon.on_call_with('test.lua').returns('*', 'test_highlight_group')
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
@@ -421,11 +414,10 @@ describe('Filetype component', function()
       icon = { align = 'right' }
     }
     assert_component('filetype', opts, 'lua *')
-    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
+    assert.stub(devicons.get_icon).was_called_with('test.lua')
     assert.stub(utils.extract_highlight_colors).was_not_called()
     assert.stub(hl.create_component_highlight_group).was_not_called()
     assert.stub(vim.fn.expand).was_called_with('%:t')
-    assert.stub(vim.fn.expand).was_called_with('%:e')
 
     devicons.get_icon:revert()
     utils.extract_highlight_colors:revert()

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -285,20 +285,24 @@ describe('Filetype component', function()
   end)
 
   it('colors nvim-web-devicons icons', function()
-    package.loaded['nvim-web-devicons'] = {
-      get_icon = function()
-        return '*', 'test_highlight_group'
-      end,
-    }
     vim.g.actual_curwin = tostring(vim.api.nvim_get_current_win())
+    stub(vim.fn, 'expand')
+    vim.fn.expand.on_call_with('%:t').returns('test.lua')
+    vim.fn.expand.on_call_with('%:e').returns('lua')
+
     local hl = require('lualine.highlight')
-    local utils = require('lualine.utils.utils')
     stub(hl, 'create_component_highlight_group')
-    stub(hl, 'format_highlight')
-    stub(utils, 'extract_highlight_colors')
     hl.create_component_highlight_group.returns { name = 'MyCompHl', no_mode = false, section = 'a' }
+    stub(hl, 'format_highlight')
     hl.format_highlight.returns('%#lualine_c_normal#')
+
+    local utils = require('lualine.utils.utils')
+    stub(utils, 'extract_highlight_colors')
     utils.extract_highlight_colors.returns('#000')
+
+    local devicons = require('nvim-web-devicons')
+    stub(devicons, 'get_icon')
+    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
@@ -308,6 +312,7 @@ describe('Filetype component', function()
       icon_only = false,
     }
     assert_component('filetype', opts, '%#MyCompHl_normal#*%#lualine_c_normal# lua%#lualine_c_normal#')
+    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
     assert.stub(utils.extract_highlight_colors).was_called_with('test_highlight_group', 'fg')
     assert.stub(hl.create_component_highlight_group).was_called_with(
       { fg = '#000' },
@@ -315,42 +320,64 @@ describe('Filetype component', function()
       opts,
       false
     )
+    assert.stub(vim.fn.expand).was_called_with('%:t')
+    assert.stub(vim.fn.expand).was_called_with('%:e')
+
+    devicons.get_icon:revert()
+    utils.extract_highlight_colors:revert()
     hl.create_component_highlight_group:revert()
     hl.format_highlight:revert()
-    utils.extract_highlight_colors:revert()
-    package.loaded['nvim-web-devicons'] = nil
+    vim.fn.expand:revert()
     vim.g.actual_curwin = nil
   end)
 
-  it("Doesn't color when colored is false", function()
-    package.loaded['nvim-web-devicons'] = {
-      get_icon = function()
-        return '*', 'test_highlight_group'
-      end,
-    }
+  it("doesn't color when colored is false", function()
+    stub(vim.fn, 'expand')
+    vim.fn.expand.on_call_with('%:t').returns('test.lua')
+    vim.fn.expand.on_call_with('%:e').returns('lua')
+
     local hl = require('lualine.highlight')
-    local utils = require('lualine.utils.utils')
     stub(hl, 'create_component_highlight_group')
+
+    local utils = require('lualine.utils.utils')
     stub(utils, 'extract_highlight_colors')
-    hl.create_component_highlight_group.returns('MyCompHl')
-    utils.extract_highlight_colors.returns('#000')
+
+    local devicons = require('nvim-web-devicons')
+    stub(devicons, 'get_icon')
+    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
+
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
       padding = 0,
       colored = false,
     }
     assert_component('filetype', opts, '* lua')
-    hl.create_component_highlight_group:revert()
+    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
+    assert.stub(utils.extract_highlight_colors).was_not_called()
+    assert.stub(hl.create_component_highlight_group).was_not_called()
+    assert.stub(vim.fn.expand).was_called_with('%:t')
+    assert.stub(vim.fn.expand).was_called_with('%:e')
+
+    devicons.get_icon:revert()
     utils.extract_highlight_colors:revert()
-    package.loaded['nvim-web-devicons'] = nil
+    hl.create_component_highlight_group:revert()
+    vim.fn.expand:revert()
   end)
 
   it('displays only icon when icon_only is true', function()
-    package.loaded['nvim-web-devicons'] = {
-      get_icon = function()
-        return '*', 'test_highlight_group'
-      end,
-    }
+    stub(vim.fn, 'expand')
+    vim.fn.expand.on_call_with('%:t').returns('test.lua')
+    vim.fn.expand.on_call_with('%:e').returns('lua')
+
+    local hl = require('lualine.highlight')
+    stub(hl, 'create_component_highlight_group')
+
+    local utils = require('lualine.utils.utils')
+    stub(utils, 'extract_highlight_colors')
+
+    local devicons = require('nvim-web-devicons')
+    stub(devicons, 'get_icon')
+    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
@@ -359,15 +386,32 @@ describe('Filetype component', function()
       icon_only = true,
     }
     assert_component('filetype', opts, '*')
-    package.loaded['nvim-web-devicons'] = nil
+    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
+    assert.stub(utils.extract_highlight_colors).was_not_called()
+    assert.stub(hl.create_component_highlight_group).was_not_called()
+    assert.stub(vim.fn.expand).was_called_with('%:t')
+    assert.stub(vim.fn.expand).was_called_with('%:e')
+
+    devicons.get_icon:revert()
+    utils.extract_highlight_colors:revert()
+    hl.create_component_highlight_group:revert()
+    vim.fn.expand:revert()
   end)
 
   it('displays right aligned icon when icon.align is "right"', function()
-    package.loaded['nvim-web-devicons'] = {
-      get_icon = function()
-        return '*', 'test_highlight_group'
-      end,
-    }
+    stub(vim.fn, 'expand')
+    vim.fn.expand.on_call_with('%:t').returns('test.lua')
+    vim.fn.expand.on_call_with('%:e').returns('lua')
+
+    local hl = require('lualine.highlight')
+    stub(hl, 'create_component_highlight_group')
+
+    local utils = require('lualine.utils.utils')
+    stub(utils, 'extract_highlight_colors')
+
+    local devicons = require('nvim-web-devicons')
+    stub(devicons, 'get_icon')
+    devicons.get_icon.on_call_with('test.lua', 'lua').returns('*', 'test_highlight_group')
 
     local opts = build_component_opts {
       component_separators = { left = '', right = '' },
@@ -377,7 +421,16 @@ describe('Filetype component', function()
       icon = { align = 'right' }
     }
     assert_component('filetype', opts, 'lua *')
-    package.loaded['nvim-web-devicons'] = nil
+    assert.stub(devicons.get_icon).was_called_with('test.lua', 'lua')
+    assert.stub(utils.extract_highlight_colors).was_not_called()
+    assert.stub(hl.create_component_highlight_group).was_not_called()
+    assert.stub(vim.fn.expand).was_called_with('%:t')
+    assert.stub(vim.fn.expand).was_called_with('%:e')
+
+    devicons.get_icon:revert()
+    utils.extract_highlight_colors:revert()
+    hl.create_component_highlight_group:revert()
+    vim.fn.expand:revert()
   end)
 end)
 


### PR DESCRIPTION
With https://github.com/kyazdani42/nvim-web-devicons/pull/125 a filetype based lookup was implemented upstream which can be used to get an icon when a file doesn't have an extension.

fixes #578