### PR TITLE
fix component(filename) add separator between filename and icons

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -80,19 +80,21 @@ M.update_status = function(self)
     end
   end
 
+  local symbols = {}
   if self.options.file_status then
     if vim.bo.modified then
-      data = data .. self.options.symbols.modified
+      table.insert(symbols, self.options.symbols.modified)
     end
     if vim.bo.modifiable == false or vim.bo.readonly == true then
-      data = data .. self.options.symbols.readonly
+      table.insert(symbols, self.options.symbols.readonly)
     end
   end
 
   if self.options.newfile_status and is_new_file() then
-    data = data .. self.options.symbols.newfile
+    table.insert(symbols, self.options.symbols.newfile)
   end
-  return data
+
+  return data .. (#symbols > 0 and ' ' .. table.concat(symbols, '') or '')
 end
 
 return M

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -491,10 +491,25 @@ describe('Filename component', function()
     vim.bo.modified = false
     assert_component('filename', opts, 'test-file.txt')
     vim.bo.modified = true
-    assert_component('filename', opts, 'test-file.txt[+]')
-    vim.bo.modified = false
+    assert_component('filename', opts, 'test-file.txt [+]')
     vim.bo.ro = true
-    assert_component('filename', opts, 'test-file.txt[-]')
+    assert_component('filename', opts, 'test-file.txt [+][-]')
+    vim.bo.modified = false
+    assert_component('filename', opts, 'test-file.txt [-]')
+    vim.cmd(':bdelete!')
+  end)
+
+  it('can show new_file_status', function ()
+    local opts = build_component_opts {
+      component_separators = { left = '', right = '' },
+      padding = 0,
+      newfile_status = true,
+      path = 0,
+    }
+    vim.cmd(':e new-file.txt')
+    assert_component('filename', opts, 'new-file.txt [New]')
+    vim.bo.modified = true
+    assert_component('filename', opts, 'new-file.txt [+][New]')
     vim.cmd(':bdelete!')
   end)
 


### PR DESCRIPTION
This makes it behave like the default statusline by have a space between the filename and the following icons (but not between the icons).

While at it, also added new test case to ensure that representation is correct, when both states (modified and readonly) are active at the same time.

fixes #794