### PR TITLE
fix: remove url-encoding chars in filename

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -62,6 +62,7 @@ M.update_status = function(self)
     data = vim.fn.expand('%:t')
   end
 
+  data = data:gsub("%%5C", "")
   data = modules.utils.stl_escape(data)
 
   if data == '' then


### PR DESCRIPTION
fixes https://github.com/nvim-lualine/lualine.nvim/issues/820