### PR TITLE
Workspace diagnostic component returns diagnostics in the wrong order

### DIFF
--- a/lua/lualine/components/diagnostics/sources.lua
+++ b/lua/lualine/components/diagnostics/sources.lua
@@ -40,8 +40,8 @@ M.sources = {
 
     return workspace_diag(diag_severity.ERROR),
       workspace_diag(diag_severity.WARN),
-      workspace_diag(diag_severity.HINT),
-      workspace_diag(diag_severity.INFO)
+      workspace_diag(diag_severity.INFO),
+      workspace_diag(diag_severity.HINT)
   end,
   nvim_diagnostic = function()
     local diagnostics = vim.diagnostic.get(0)


### PR DESCRIPTION
In the status bar, Left is "nvim_workspace_diagnostic", Right is "nvim_diagnostic"

<img width="960" alt="image" src="https://user-images.githubusercontent.com/71731492/188754980-ecd17eba-8342-40ee-bc90-9ce9e997afbe.png">
