### PR TITLE
Support extracting `special` color from highlight group

### DIFF
--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -78,6 +78,7 @@ function M.get_lualine_hl(name)
     local hl_def = {
       fg = hl.fg ~= 'None' and vim.deepcopy(hl.fg) or nil,
       bg = hl.bg ~= 'None' and vim.deepcopy(hl.bg) or nil,
+      sp = hl.sp ~= 'None' and vim.deepcopy(hl.sp) or nil,
     }
     if hl.gui then
       for _, flag in ipairs(vim.split(hl.gui, ',')) do

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -5,7 +5,7 @@ local M = {}
 -- Note for now only works for termguicolors scope can be bg or fg or any other
 -- attr parameter like bold/italic/reverse
 ---@param color_group string hl_group name
----@param scope       string bg | fg
+---@param scope       string bg | fg | sp
 ---@return table|string returns #rrggbb formatted color when scope is specified
 ----                       or complete color table when scope isn't specified
 function M.extract_highlight_colors(color_group, scope)
@@ -22,6 +22,10 @@ function M.extract_highlight_colors(color_group, scope)
     if color.foreground ~= nil then
       color.fg = string.format('#%06x', color.foreground)
       color.foreground = nil
+    end
+    if color.special ~= nil then
+      color.sp = string.format('#%06x', color.special)
+      color.special = nil
     end
   end
   if scope then

--- a/tests/spec/utils_spec.lua
+++ b/tests/spec/utils_spec.lua
@@ -11,11 +11,11 @@ describe('Utils', function()
   local utils = require('lualine.utils.utils')
 
   it('can retrive highlight groups', function()
-    local hl2 = { fg = '#aabbcc', bg = '#889977', reverse = true }
+    local hl2 = { fg = '#aabbcc', bg = '#889977', sp = '#997788', reverse = true, undercurl = true }
     -- handles non existing hl groups
     eq(utils.extract_highlight_colors('hl2'), nil)
     -- create highlight
-    vim.cmd(string.format('hi hl2 guifg=%s guibg=%s gui=reverse', hl2.fg, hl2.bg))
+    vim.cmd(string.format('hi hl2 guifg=%s guibg=%s guisp=%s gui=reverse,undercurl', hl2.fg, hl2.bg, hl2.sp))
     -- Can retrieve entire highlight table
     eq(utils.extract_highlight_colors('hl2'), hl2)
     -- Can retrieve specific parts of highlight


### PR DESCRIPTION
Besides `background` and `foreground`, (Neo)vim highlight groups have a `special` attribute that can be used for setting the color of underlines. (See `:h nvim_set_hl()`)

I happen to be working with a color scheme which sets the highlight style of `DiagnosticHint`, etc. to a colored `undercurl` instead of a foreground color:

```lua
c = vim.api.nvim_get_hl_by_name('DiagnosticHint', true)

for attr in pairs(c) do
  print(attr)
end

--[[ print
special
undercurl
--]]
```

This PR provides access to this attribute via the `extract_highlight_colors()` function.

Example:

```lua
warn = { fg = utils.extract_color_from_hllist('sp', {'DiagnosticWarn'}, '#ffa500') }
```