### PR TITLE
fix: display virtual column number in location component

### DIFF
--- a/lua/lualine/components/location.lua
+++ b/lua/lualine/components/location.lua
@@ -2,7 +2,7 @@
 -- MIT license, see LICENSE for more details.
 local function location()
   local line = vim.fn.line('.')
-  local col = vim.fn.col('.')
+  local col = vim.fn.virtcol('.')
   return string.format('%3d:%-2d', line, col)
 end
 

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -405,6 +405,12 @@ describe('Location component', function()
     assert_component('location', opts, ' 10:1 ')
     vim.api.nvim_win_set_cursor(0, {5, 0})
     assert_component('location', opts, '  5:1 ')
+    -- test column number
+    vim.cmd('normal! oTest')
+    assert_component('location', opts, '  6:4 ')
+    -- test column number in line containing cyrillic symbols
+    vim.cmd('normal! oТест')
+    assert_component('location', opts, '  7:4 ')
     vim.cmd('bdelete!')
   end)
 end)


### PR DESCRIPTION
In location component, display screen column number, not byte length.
This is relevant for lines containing non-latin symbols.

The same issue https://github.com/nvim-lualine/lualine.nvim/issues/362 was already fixed once, but then it was broken again.