### PR TITLE
Add harpoon component

### DIFF
--- a/lua/lualine/components/harpoon.lua
+++ b/lua/lualine/components/harpoon.lua
@@ -1,0 +1,28 @@
+-- MIT license, see LICENSE for more details.
+local M = require('lualine.component'):extend()
+
+local modules = require('lualine_require').lazy_require {
+  utils = 'lualine.utils.utils',
+  harpoon_mark = 'harpoon.mark'
+}
+
+local mark_cache = {}
+local changes = 0
+
+M.init = function(self, options)
+  M.super.init(self, options)
+  if not self.options.icon then
+    self.options.icon = 'ﯠ' -- fbe0
+  end
+end
+
+M.update_status = function(_, is_focused)
+  mark = modules.harpoon_mark.get_current_index()
+  if mark then
+    return modules.utils.stl_escape(tostring(mark))
+  else
+    return ''
+  end
+end
+
+return M


### PR DESCRIPTION
Creates a component that works with harpoon (https://github.com/ThePrimeagen/harpoon) showing the current file's harpoon index (if it exists). Right now this is a proof of concept. I want to hear your opinion on adding components for third-party plugins. This functionality couldn't be added as an extension because it doesn't involve a separate file type.

Todo:
* cache indicies
* use hook off icon, add colors, etc
* documentation