### PR TITLE
Test on nvim-0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
             runner: ubuntu-20.04
             os: linux
             nvim_version: v0.7.0
+          - flavor: nvim-0.8
+            runner: ubuntu-20.04
+            os: linux
+            nvim_version: v0.8.0
           - flavor: nvim-nightly
             runner: ubuntu-20.04
             os: linux


### PR DESCRIPTION
nvim 0.8 was released and tests should run on the latest stable version.