### PR TITLE
Add fzf-lua extension

### DIFF
--- a/lua/lualine/extensions/fzf.lua
+++ b/lua/lualine/extensions/fzf.lua
@@ -1,5 +1,34 @@
--- Copyright (c) 2020-2021 hoob3rt
--- MIT license, see LICENSE for more details.
+--[[
+lualine extension for fzf filetypes:
+works with both https://github.com/junegunn/fzf.vim and https://github.com/ibhagwan/fzf-lua
+
+-- fzf-lua must be set-up in split mode
+]]
+
+local fzf_lua, _ = pcall(require, 'fzf-lua')
+
+local function fzf_picker()
+  if not fzf_lua then
+    return ''
+  end
+
+  local info_string = vim.inspect(require('fzf-lua').get_info()['fnc'])
+  return info_string:gsub('"', '')
+end
+
+local function fzf_element()
+  if not fzf_lua then
+    return ''
+  end
+
+  local info_string = vim.inspect(require('fzf-lua').get_info()['selected'])
+  local lines = {}
+  for w in info_string:gsub('"', ''):gmatch('%S+') do
+    table.insert(lines, w)
+  end
+  return lines[1]
+end
+
 local function fzf_statusline()
   return 'FZF'
 end
@@ -8,6 +37,8 @@ local M = {}
 
 M.sections = {
   lualine_a = { fzf_statusline },
+  lualine_y = { fzf_element },
+  lualine_z = { fzf_picker },
 }
 
 M.filetypes = { 'fzf' }


### PR DESCRIPTION
This PR adds a statusline extension for [fzf-lua](https://github.com/ibhagwan/fzf-lua), in particular it addresses the discussion we had in https://github.com/nvim-lualine/lualine.nvim/issues/860.

See [cross-post](https://github.com/ibhagwan/fzf-lua/issues/537) for additional reference.

Below is a screen recording showing what it looks like in action :)


https://user-images.githubusercontent.com/15387611/194726388-8ee88056-6d15-4e78-8e22-a6d3b989590d.mov

