### PR TITLE
feat: added searchcount component

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ sections = {lualine_a = {'mode'}}
 - `filetype`
 - `hostname`
 - `location` (location in file in line:column format)
-- `searchcount` (number of search matches when hlsearch is active)
 - `mode` (vim mode)
 - `progress` (%progress in file)
+- `searchcount` (number of search matches when hlsearch is active)
 - `tabs` (shows currently available tabs)
 - `windows` (shows currently available windows)
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ sections = {lualine_a = {'mode'}}
 - `filetype`
 - `hostname`
 - `location` (location in file in line:column format)
+- `searchcount` (number of search matches when hlsearch is active)
 - `mode` (vim mode)
 - `progress` (%progress in file)
 - `tabs` (shows currently available tabs)

--- a/lua/lualine/components/searchcount.lua
+++ b/lua/lualine/components/searchcount.lua
@@ -1,0 +1,11 @@
+local function searchcount()
+  if vim.v.hlsearch == 0 then
+    return ""
+  end
+
+  local result = vim.fn.searchcount()
+  local denominator = math.min(result.total, result.maxcount)
+  return string.format("[%d/%d]", result.current, denominator)
+end
+
+return searchcount

--- a/lua/lualine/components/searchcount.lua
+++ b/lua/lualine/components/searchcount.lua
@@ -3,7 +3,7 @@ local function searchcount()
     return ""
   end
 
-  local result = vim.fn.searchcount()
+  local result = vim.fn.searchcount({ maxcount = 999, timeout = 500 })
   local denominator = math.min(result.total, result.maxcount)
   return string.format("[%d/%d]", result.current, denominator)
 end


### PR DESCRIPTION
Hello :wave: Now with `cmdheight=0`, the search count `[x/x]` that used to be in the right of the command mode buffer when navigating search results is hidden. I added a simple function to restore it via `lualine`, and thought it might be worthwhile to contribute upstream.

Happy to add a bit of documentation in the appropriate locations if this is a welcomed idea