### PR TITLE
Fixes bug with string interpolation from 3rd party functions

### DIFF
--- a/lua/lualine/components/special/eval_func_component.lua
+++ b/lua/lualine/components/special/eval_func_component.lua
@@ -20,6 +20,8 @@ function M:update_status()
       status = M.vim_function(component)
     end
   end
+  
+  status = string.gsub(status, "%%", "%%%%")
   return status
 end
 

--- a/lua/lualine/components/special/eval_func_component.lua
+++ b/lua/lualine/components/special/eval_func_component.lua
@@ -20,7 +20,6 @@ function M:update_status()
       status = M.vim_function(component)
     end
   end
-  
   status = string.gsub(status, "%%", "%%%%")
   return status
 end


### PR DESCRIPTION
This fixes a bug I experienced when using lualine with lsp-status and Elixir.

```elixir
  defp build_slack_message(%{asset: asset, project: project, parent: parent} = comment) do
    timecode = comment |> timestamp(parent) |> Core.Timecode.generate(asset.fps)
    user = Comments.author(comment)
 ```

A function like the above would return the function head as a string and result in a Lua formatting error "E121: variable asset not defined". By properly escaping the % sign the bug is fixed.