### PR TITLE
Fix Solarized b/y section backgrounds for legibility against color text

### DIFF
--- a/lua/lualine/themes/solarized_dark.lua
+++ b/lua/lualine/themes/solarized_dark.lua
@@ -24,7 +24,7 @@ local colors = {
 return {
   normal = {
     a = { fg = colors.base03, bg = colors.blue, gui = 'bold' },
-    b = { fg = colors.base03, bg = colors.base1 },
+    b = { fg = colors.base03, bg = colors.base2 },
     c = { fg = colors.base1, bg = colors.base02 },
   },
   insert = { a = { fg = colors.base03, bg = colors.green, gui = 'bold' } },

--- a/lua/lualine/themes/solarized_light.lua
+++ b/lua/lualine/themes/solarized_light.lua
@@ -24,7 +24,7 @@ local colors = {
 return {
   normal = {
     a = { fg = colors.base03, bg = colors.blue, gui = 'bold' },
-    b = { fg = colors.base03, bg = colors.base1 },
+    b = { fg = colors.base03, bg = colors.base2 },
     c = { fg = colors.base1, bg = colors.base02 },
   },
   insert = { a = { fg = colors.base03, bg = colors.green, gui = 'bold' } },


### PR DESCRIPTION
I found it difficult to read color text in the b/y sections against the existing default background. Switching the default background color to the opposite mode's background highlight (i.e. `base2` for `solarized_dark`) seems more legible for me.

Dark before: ![solarized-dark-before](https://user-images.githubusercontent.com/28759022/202872090-f982fc37-8c8c-4c60-9196-a641e55bc170.png)
Dark after: 
![solarized-dark-after](https://user-images.githubusercontent.com/28759022/202872115-2d9a1251-d6bf-4f0d-95fd-4792173b48e4.png)
Light before:
![solarized-light-before](https://user-images.githubusercontent.com/28759022/202872130-15dace87-d3e0-418a-aa94-96caa203daca.png)
Light after:
![solarized-light-after](https://user-images.githubusercontent.com/28759022/202872135-bf045962-8130-4be3-bc0f-cdbc85bd1e7e.png)

