### PR TITLE
feat: Add extensions for Alpha and help (pager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,16 +824,19 @@ extensions = {'quickfix'}
 #### Available extensions
 
 - aerial
+- alpha
 - chadtree
 - fern
 - fugitive
 - fzf
+- help
 - man
 - mundo
 - neo-tree
 - nerdtree
 - nvim-dap-ui
 - nvim-tree
+- pager
 - quickfix
 - symbols-outline
 - toggleterm

--- a/lua/lualine/extensions/alpha.lua
+++ b/lua/lualine/extensions/alpha.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+M.sections = {
+  lualine_a = {
+    function()
+      return string.upper(vim.bo.filetype)
+    end,
+  },
+}
+
+M.filetypes = { 'alpha' }
+
+return M

--- a/lua/lualine/extensions/help.lua
+++ b/lua/lualine/extensions/help.lua
@@ -3,6 +3,6 @@ local M = {}
 
 M.sections = vim.deepcopy(pager.sections)
 
-M.filetypes = { 'man' }
+M.filetypes = { 'help' }
 
 return M

--- a/lua/lualine/extensions/pager.lua
+++ b/lua/lualine/extensions/pager.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+M.sections = {
+  lualine_a = {
+    function()
+      return string.upper(vim.bo.filetype)
+    end,
+  },
+  lualine_b = { { 'filename', file_status = false } },
+  lualine_y = { 'progress' },
+}
+
+M.filetypes = {
+  'help',
+  'man',
+}
+
+return M


### PR DESCRIPTION
- Added extension for [Alpha](https://github.com/goolord/alpha-nvim)
- Added extension `pager` that handles paging RO docs (help, man)
- Added extension `help`
- Updated extension `man` to use sections from `pager`
- Updated `README.md`

As it stands, help and man are separated out so they can be activated selectively, but enabling the `pager` extension turns on both.