### PR TITLE
docs: Update nvim-web-devicons references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Good luck!
   and run tests with [plenary-test][plenary.nvim] these will be ran on CI. If you want you can run tests & linter
   locally with `make test` & `make lint` respectively. Or `make check` to run both linter & tests. For running
   tests you'll have to make sure lualine.nvim, [plenary.nvim][plenary.nvim] and
-  [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) are in same directory.
+  [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) are in same directory.
 - Lua codebase gets formatted with [stylua](https://github.com/JohnnyMorganz/StyLua) in CI.
   So you can ignore formatting. But if you want to submit formatted
   PR you can run formatter locally with `make format`.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Last Updated On: 18-04-2022
 
 ```vim
 Plug 'nvim-lualine/lualine.nvim'
-" If you want to have icons in your statusline choose one of these
-Plug 'kyazdani42/nvim-web-devicons'
+" If you want to have icons in your statusline
+Plug 'nvim-tree/nvim-web-devicons'
 ```
 
 ### [packer.nvim](https://github.com/wbthomason/packer.nvim)
@@ -81,7 +81,7 @@ Plug 'kyazdani42/nvim-web-devicons'
 ```lua
 use {
   'nvim-lualine/lualine.nvim',
-  requires = { 'kyazdani42/nvim-web-devicons', opt = true }
+  requires = { 'nvim-tree/nvim-web-devicons', opt = true }
 }
 ```
 

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -52,8 +52,8 @@ VIM-PLUG <HTTPS://GITHUB.COM/JUNEGUNN/VIM-PLUG> ~
 
 >
     Plug 'nvim-lualine/lualine.nvim'
-    " If you want to have icons in your statusline choose one of these
-    Plug 'kyazdani42/nvim-web-devicons'
+    " If you want to have icons in your statusline
+    Plug 'nvim-tree/nvim-web-devicons'
 <
 
 
@@ -62,7 +62,7 @@ PACKER.NVIM <HTTPS://GITHUB.COM/WBTHOMASON/PACKER.NVIM> ~
 >
     use {
       'nvim-lualine/lualine.nvim',
-      requires = { 'kyazdani42/nvim-web-devicons', opt = true }
+      requires = { 'nvim-tree/nvim-web-devicons', opt = true }
     }
 <
 


### PR DESCRIPTION
The `nvim-web-devicons` repo was transferred from `kyazdani42/nvim-web-devicons` to `nvim-tree/nvim-web-devicons`.

This updates the docs to point to the updated repo.