### PR TITLE
Protect call inside `set` to avoid `dressing` winbar error

### DIFF
--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -74,7 +74,7 @@ function M.set(name, val, opts)
     set_opt(name, val, function(nm)
       return vim.api.nvim_win_get_option(opts.window, nm)
     end, function(nm, vl)
-      vim.api.nvim_win_set_option(opts.window, nm, vl)
+      pcall(vim.api.nvim_win_set_option, opts.window, nm, vl)
     end, options.window[opts.window])
   end
 end


### PR DESCRIPTION
The recent winbar feature produces an error while using both the `lualine` and the `dressing` packages.
This is because when `dressing` input creates a virtual window, `lualine` tries to set a value to its empty winbar.
It cannot be filtered out in any way as this `set` seems to happen before the filetype is even set for the new window.
The only way I found to solve this issue is to wrap the `nvim_win_set_option` with a protected call, so it doesn't report an error and freeze the execution for a second.
I don't think there should be a problem for this, as this error is not handled anyway, only reported to the user, and it doesn't actually break the mentioned window.