### PR TITLE
Passing self as second arg to self.options.fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,11 @@ sections = {
                    --   padding = { left = left_padding, right = right_padding }
 
       fmt = nil,   -- Format function, formats the component's output.
+                   -- This function receives two arguments:
+                   -- - string that is going to be displayed and
+                   --   that can be changed, enhanced and etc.
+                   -- - context object with information you might
+                   --   need. E.g. tabnr if used with tabs.
       on_click = nil, -- takes a function that is called when component is clicked with mouse.
                    -- the function receives several arguments
                    -- - number of clicks incase of multiple clicks
@@ -650,6 +655,16 @@ sections = {
         active = 'lualine_{section}_normal',     -- Color for active tab.
         inactive = 'lualine_{section}_inactive', -- Color for inactive tab.
       },
+
+      fmt = function(name, context)
+        -- Show + if buffer is modified in tab
+        local buflist = vim.fn.tabpagebuflist(context.tabnr)
+        local winnr = vim.fn.tabpagewinnr(context.tabnr)
+        local bufnr = buflist[winnr]
+        local mod = vim.fn.getbufvar(bufnr, '&mod')
+
+        return name .. (mod == 1 and ' +' or '')
+      end
     }
   }
 }

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -272,7 +272,7 @@ function M:draw(default_highlight, is_focused)
   self.default_hl = default_highlight
   local status = self:update_status(is_focused)
   if self.options.fmt then
-    status = self.options.fmt(status or '')
+    status = self.options.fmt(status or '', self)
   end
   if type(status) == 'string' and #status > 0 then
     self.status = status

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -69,7 +69,7 @@ end
 function Buffer:render()
   local name = self:name()
   if self.options.fmt then
-    name = self.options.fmt(name or '')
+    name = self.options.fmt(name or '', self)
   end
 
   if self.ellipse then -- show ellipsis

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -51,7 +51,7 @@ end
 function Tab:render()
   local name = self:label()
   if self.options.fmt then
-    name = self.options.fmt(name or '')
+    name = self.options.fmt(name or '', self.tabnr)
   end
   if self.ellipse then -- show ellipsis
     name = '...'

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -51,7 +51,7 @@ end
 function Tab:render()
   local name = self:label()
   if self.options.fmt then
-    name = self.options.fmt(name or '', self.tabnr)
+    name = self.options.fmt(name or '', self)
   end
   if self.ellipse then -- show ellipsis
     name = '...'


### PR DESCRIPTION
I found this undocumented option and it is really useful if I want
to show if buffer is modified in tabline. However I need `tabnr`
for that.
