### PR TITLE
Add options to the Tabs module to align it with the Buffers module

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,11 @@ sections = {
         inactive = 'lualine_{section}_inactive', -- Color for inactive tab.
       },
 
+      show_modified_status = true,  -- Shows a symbol next to the tab name if the file has been modified.
+      symbols = {
+        modified = '[+]',  -- Text to show when the file is modified.
+      },
+
       fmt = function(name, context)
         -- Show + if buffer is modified in tab
         local buflist = vim.fn.tabpagebuflist(context.tabnr)

--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ sections = {
   lualine_a = {
     {
       'tabs',
+      tab_max_length = 40,  -- Maximum width of each tab. The content will be shorten dynamically (example: apple/orange -> a/orange)
       max_length = vim.o.columns / 3, -- Maximum width of tabs component.
                                       -- Note:
                                       -- It can also be a function that returns
@@ -687,7 +688,7 @@ sections = {
                 -- 1: Shows tab_name
                 -- 2: Shows tab_nr + tab_name
 
-      path = 0  -- 0: just shows the filename
+      path = 0, -- 0: just shows the filename
                 -- 1: shows the relative path and shorten $HOME to ~
                 -- 2: shows the full path
                 -- 3: shows the full path and shorten $HOME to ~

--- a/README.md
+++ b/README.md
@@ -687,6 +687,11 @@ sections = {
                 -- 1: Shows tab_name
                 -- 2: Shows tab_nr + tab_name
 
+      path = 0  -- 0: just shows the filename
+                -- 1: shows the relative path and shorten $HOME to ~
+                -- 2: shows the full path
+                -- 3: shows the full path and shorten $HOME to ~
+
       -- Automatically updates active tab color to match color of other components (will be overidden if buffers_color is set)
       use_mode_colors = false,
 

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -15,6 +15,10 @@ local default_options = {
     active = nil,
     inactive = nil,
   },
+  show_modified_status = true,
+  symbols = {
+    modified = '[+]',
+  },
 }
 
 -- This function is duplicated in buffers

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -9,6 +9,7 @@ local default_options = {
   max_length = 0,
   mode = 0,
   use_mode_colors = false,
+  path = 0,
   tabs_color = {
     active = nil,
     inactive = nil,

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -7,6 +7,7 @@ local highlight = require('lualine.highlight')
 
 local default_options = {
   max_length = 0,
+  tab_max_length = 40,
   mode = 0,
   use_mode_colors = false,
   path = 0,

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -13,6 +13,7 @@ function Tab:init(opts)
   self.tabId = opts.tabId
   self.options = opts.options
   self.highlights = opts.highlights
+  self.modified_icon = ''
   self:get_props()
 end
 
@@ -23,6 +24,16 @@ function Tab:get_props()
   self.file = modules.utils.stl_escape(vim.api.nvim_buf_get_name(bufnr))
   self.filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
   self.buftype = vim.api.nvim_buf_get_option(bufnr, 'buftype')
+
+  if self.options.show_modified_status then
+    for _, b in ipairs(buflist) do
+      if vim.api.nvim_buf_get_option(b, 'modified') then
+        self.modified_icon = self.options.symbols.modified or ''
+        break
+      end
+    end
+  end
+
 end
 
 ---returns name for tab. Tabs name is the name of buffer in last active window
@@ -100,12 +111,18 @@ function Tab:render()
     -- different formats for different modes
     if self.options.mode == 0 then
       name = tostring(self.tabnr)
+      if self.modified_icon ~= '' then
+        name = string.format('%s%s', name, self.modified_icon)
+      end
     elseif self.options.mode == 1 then
-      name = name
+      if self.modified_icon ~= '' then
+        name = string.format('%s %s', self.modified_icon, name)
+      end
     else
-      name = string.format('%s %s', tostring(self.tabnr), name)
+      name = string.format('%s%s %s', tostring(self.tabnr), self.modified_icon, name)
     end
   end
+
   name = Tab.apply_padding(name, self.options.padding)
   self.len = vim.fn.strchars(name)
 

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -57,10 +57,40 @@ function Tab:label()
   end
 end
 
+---shortens path by turning apple/orange -> a/orange
+---@param path string
+---@param sep string path separator
+---@param max_len integer maximum length of the full filename string
+---@return string
+local function shorten_path(path, sep, max_len)
+  local len = #path
+  if len <= max_len then
+    return path
+  end
+
+  local segments = vim.split(path, sep)
+  for idx = 1, #segments - 1 do
+    if len <= max_len then
+      break
+    end
+
+    local segment = segments[idx]
+    local shortened = segment:sub(1, vim.startswith(segment, '.') and 2 or 1)
+    segments[idx] = shortened
+    len = len - (#segment - #shortened)
+  end
+
+  return table.concat(segments, sep)
+end
+
 ---returns rendered tab
 ---@return string
 function Tab:render()
   local name = self:label()
+  if self.options.tab_max_length ~= 0 then
+    local path_separator = package.config:sub(1, 1)
+    name = shorten_path(name, path_separator, self.options.tab_max_length)
+  end
   if self.options.fmt then
     name = self.options.fmt(name or '', self)
   end


### PR DESCRIPTION
Allow to switch between different `path` modes:
  * `0`: just shows the filename
  * `1`: shows the relative path and shorten `$HOME` to `~`
  * `2`: shows the full path
  * `3`: shows the full path and shorten `$HOME` to `~`

Add an option to set the tab max size (`0` to disable), and uses the same logic as the Buffers module to dynamically shorten the path when the max size is reached.

Add a "modified status", mimicking the default vim/nvim tab bar by showing a symbol when a buffer contained by the tab is modified.