### PR TITLE
added colours to qf extension to distinguish quickfix and location list

### DIFF
--- a/lua/lualine/extensions/quickfix.lua
+++ b/lua/lualine/extensions/quickfix.lua
@@ -18,7 +18,7 @@ end
 
 local M = {}
 
-function M.init()
+function M.get_colours()
   -- Make sure ft wf doesn't create a custom statusline
   vim.g.qf_disable_statusline = true
   return {
@@ -32,7 +32,7 @@ M.sections = {
     {
       label,
       color = function()
-        return is_loclist() and { bg = M.init()['ll'] } or { bg = M.init()['qf'] }
+        return is_loclist() and { bg = M.get_colours()['ll'] } or { bg = M.get_colours()['qf'] }
       end,
     },
   },

--- a/lua/lualine/extensions/quickfix.lua
+++ b/lua/lualine/extensions/quickfix.lua
@@ -21,10 +21,21 @@ local M = {}
 function M.init()
   -- Make sure ft wf doesn't create a custom statusline
   vim.g.qf_disable_statusline = true
+  return {
+    ll = vim.api.nvim_get_hl_by_name('Constant', false).foreground,
+    qf = vim.api.nvim_get_hl_by_name('Identifier', false).foreground,
+  }
 end
 
 M.sections = {
-  lualine_a = { label },
+  lualine_a = {
+    {
+      label,
+      color = function()
+        return is_loclist() and { bg = M.init()['ll'] } or { bg = M.init()['qf'] }
+      end,
+    },
+  },
   lualine_b = { title },
   lualine_z = { 'location' },
 }

--- a/lua/lualine/extensions/quickfix.lua
+++ b/lua/lualine/extensions/quickfix.lua
@@ -16,15 +16,16 @@ local function title()
   return vim.fn.getqflist({ title = 0 }).title
 end
 
+local qf_colours = {
+  ll = vim.api.nvim_get_hl_by_name('Constant', false).foreground,
+  qf = vim.api.nvim_get_hl_by_name('Identifier', false).foreground,
+}
+
 local M = {}
 
-function M.get_colours()
+function M.init()
   -- Make sure ft wf doesn't create a custom statusline
   vim.g.qf_disable_statusline = true
-  return {
-    ll = vim.api.nvim_get_hl_by_name('Constant', false).foreground,
-    qf = vim.api.nvim_get_hl_by_name('Identifier', false).foreground,
-  }
 end
 
 M.sections = {
@@ -32,7 +33,7 @@ M.sections = {
     {
       label,
       color = function()
-        return is_loclist() and { bg = M.get_colours()['ll'] } or { bg = M.get_colours()['qf'] }
+        return is_loclist() and { bg = qf_colours['ll'] } or { bg = qf_colours['qf'] }
       end,
     },
   },


### PR DESCRIPTION
This PR introduces colours to distinguish between quickfix and location list (see screenshot below): I have been using it locally myself for a time and thought to propose it as a PR, should it be of interest for others too.

At the moment I have configured hardcoded highlight colours, however ideally the users could pass them as arguments: I have not been able to understand how (and if) it is possible; I would imagine something along the lines of
```lua

lualine.setup({
    extensions = { 
        quickfix.setup{ qf = '#...', ll = '#...'}, 
        ...
    }
}
```
perhaps you can direct me to how to achieve it (and I could improve the PR).

https://user-images.githubusercontent.com/15387611/211216863-5ba09dac-45e7-48e8-8b8b-8f03139f05b4.mov

