### PR TITLE
feat: Add separator_always_visible component option

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ sections = {
                             -- and right will be placed on its right.
                             --
 
+	    separator_always_visible = nil, -- Allows the component separator to always be visible even if the component output is empty
       cond = nil,           -- Condition function, the component is loaded when the function returns `true`.
 
       -- Defines a custom color for the component:

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -429,7 +429,7 @@ General component options              These are options that control behavior
                                 -- Where left will be placed on left side of component,
                                 -- and right will be placed on its right.
                                 --
-    
+	  separator_always_visible = nil, -- Allows the component separator to always be visible even if the component output is empty
           cond = nil,           -- Condition function, the component is loaded when the function returns `true`.
     
           -- Defines a custom color for the component:

--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -274,11 +274,13 @@ function M:draw(default_highlight, is_focused)
   if self.options.fmt then
     status = self.options.fmt(status or '', self)
   end
-  if type(status) == 'string' and #status > 0 then
+  if type(status) == 'string' and (#status > 0 or self.options.separator_always_visible) then
     self.status = status
-    self:apply_icon()
-    self:apply_padding()
-    self:apply_on_click()
+    if #status > 0 then
+      self:apply_icon()
+      self:apply_padding()
+      self:apply_on_click()
+    end
     self:apply_highlights(default_highlight)
     self:apply_section_separators()
     self:apply_separator()


### PR DESCRIPTION
Allows the component separator always to be visible even if the component output is empty

![Screenshot 2023-01-31 at 4 29 13 AM](https://user-images.githubusercontent.com/13323913/215739222-0aa9aa66-ae34-40e7-ab78-010f49a24b74.png)
![Screenshot 2023-01-31 at 4 29 38 AM](https://user-images.githubusercontent.com/13323913/215739224-87dfda90-389e-4b52-903d-f082b365d5de.png)
![Screenshot 2023-01-31 at 4 30 46 AM](https://user-images.githubusercontent.com/13323913/215739225-6d47a213-2760-4c04-bbb0-6bf2c0bf27d7.png)
![Screenshot 2023-01-31 at 5 16 13 AM](https://user-images.githubusercontent.com/13323913/215739234-bb45601c-1dbe-4722-b64f-6ee0512b642d.png)
![Screenshot 2023-01-31 at 6 02 04 AM](https://user-images.githubusercontent.com/13323913/215743001-5571e154-2ca1-4cb0-8555-c980acbcff6a.png)


Screenshots coming from the Diagnostics component

```
sections = {
  lualine_x = {
    	{
		function()
			return ""
		end,
		separator = { left = "" },
		color = { bg = "#dfdfe0" },
		separator_always_visible = true,
	},
	{
		"diagnostics",
		sections = { "error" },
		separator = { left = "" },
		colored = false,
		color = { bg =  "#ec5f67", fg = "#dfdfe0" },
		separator_always_visible = true,
	},
	{
		"diagnostics",
		sections = { "warn" },
		separator = { left = "" },
		colored = false,
		color = { bg = "#dbc074", fg = "#ffffff" },
		separator_always_visible = true,
	},
	{
		"diagnostics",
		sections = { "info" },
		separator = { left = "" },
		colored = false,
		color = { bg =  "#51afef", fg = "#dfdfe0" },
		separator_always_visible = true,
	},
	{
		"diagnostics",
		sections = { "hint" },
		separator = { left = "" },
		colored = false,
		color = { bg =  "#008080", fg = "#dfdfe0" },
		separator_always_visible = true,
	},
  }
}
```