### PR TITLE
feat: add selectioncount component

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ sections = {lualine_a = {'mode'}}
 - `mode` (vim mode)
 - `progress` (%progress in file)
 - `searchcount` (number of search matches when hlsearch is active)
+- `selectioncount` (number of selected characters or lines)
 - `tabs` (shows currently available tabs)
 - `windows` (shows currently available windows)
 

--- a/lua/lualine/components/selectioncount.lua
+++ b/lua/lualine/components/selectioncount.lua
@@ -1,0 +1,16 @@
+local function selectioncount()
+  local mode = vim.fn.mode(true)
+  local line_start, col_start = vim.fn.line("v"), vim.fn.col("v")
+  local line_end, col_end = vim.fn.line("."), vim.fn.col(".")
+  if mode:match("") then
+      return string.format('%dx%d', math.abs(line_start-line_end)+1, math.abs(col_start-col_end)+1)
+  elseif mode:match("V") or line_start ~= line_end then
+    return math.abs(line_start - line_end) + 1
+  elseif mode:match("v") then
+    return math.abs(col_start - col_end) + 1
+  else
+      return ''
+  end
+end
+
+return selectioncount


### PR DESCRIPTION
### Description:

Implement `selectioncount` component, which shows:
- number of selected characters if selection is within one line,
- number of selected lines if more than one line selected,
- "lines x characters" if mode is visual block.

This is useful in case of `vim.go.cmdheight = 0` option set.

---

### Credits:
- @kraftwerk28 - basic implementation,
- @dmyTRUEk - enhancement.