### PR TITLE
Fix dynamic coloring of tabline/winbar components

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,9 @@ sections = {
         alpha = 'Alpha'
       }, -- Shows specific buffer name for that filetype ( { `filetype` = `buffer_name`, ... } )
 
+      -- Automatically updates active buffer color to match color of other components (will be overidden if buffers_color is set)
+      use_mode_colors = false,
+
       buffers_color = {
         -- Same values as the general color option can be used here.
         active = 'lualine_{section}_normal',     -- Color for active buffer.
@@ -650,6 +653,9 @@ sections = {
                 -- 1: Shows tab_name
                 -- 2: Shows tab_nr + tab_name
 
+      -- Automatically updates active tab color to match color of other components (will be overidden if buffers_color is set)
+      use_mode_colors = false,
+
       tabs_color = {
         -- Same values as the general color option can be used here.
         active = 'lualine_{section}_normal',     -- Color for active tab.
@@ -696,6 +702,9 @@ sections = {
       }, -- Shows specific window name for that filetype ( { `filetype` = `window_name`, ... } )
 
       disabled_buftypes = { 'quickfix', 'prompt' }, -- Hide a window if its buffer's type is disabled
+
+      -- Automatically updates active window color to match color of other components (will be overidden if buffers_color is set)
+      use_mode_colors = false,
 
       windows_color = {
         -- Same values as the general color option can be used here.

--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -18,6 +18,7 @@ local default_options = {
     fzf = 'FZF',
     alpha = 'Alpha',
   },
+  use_mode_colors = false,
   buffers_color = {
     active = nil,
     inactive = nil,
@@ -35,7 +36,7 @@ local default_options = {
 ---@param is_active boolean
 ---@return string hl name
 local function get_hl(section, is_active)
-  local suffix = is_active and '_normal' or '_inactive'
+  local suffix = is_active and highlight.get_mode_suffix() or '_inactive'
   local section_redirects = {
     lualine_x = 'lualine_c',
     lualine_y = 'lualine_b',
@@ -49,8 +50,12 @@ end
 
 function M:init(options)
   M.super.init(self, options)
+  -- if use_mode_colors is set, use a function so that the colors update
+  local default_active = options.use_mode_colors and
+      function() return get_hl('lualine_' .. options.self.section, true) end
+      or get_hl('lualine_' .. options.self.section, true)
   default_options.buffers_color = {
-    active = get_hl('lualine_' .. options.self.section, true),
+    active = default_active,
     inactive = get_hl('lualine_' .. options.self.section, false),
   }
   self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)

--- a/lua/lualine/components/tabs/init.lua
+++ b/lua/lualine/components/tabs/init.lua
@@ -8,6 +8,7 @@ local highlight = require('lualine.highlight')
 local default_options = {
   max_length = 0,
   mode = 0,
+  use_mode_colors = false,
   tabs_color = {
     active = nil,
     inactive = nil,
@@ -20,7 +21,7 @@ local default_options = {
 ---@param is_active boolean
 ---@return string hl name
 local function get_hl(section, is_active)
-  local suffix = is_active and '_normal' or '_inactive'
+  local suffix = is_active and highlight.get_mode_suffix() or '_inactive'
   local section_redirects = {
     lualine_x = 'lualine_c',
     lualine_y = 'lualine_b',
@@ -34,15 +35,19 @@ end
 
 function M:init(options)
   M.super.init(self, options)
+  -- if use_mode_colors is set, use a function so that the colors update
+  local default_active = options.use_mode_colors and
+      function() return get_hl('lualine_' .. options.self.section, true) end
+      or get_hl('lualine_' .. options.self.section, true)
   default_options.tabs_color = {
-    active = get_hl('lualine_' .. options.self.section, true),
+    active = default_active,
     inactive = get_hl('lualine_' .. options.self.section, false),
   }
   self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
   -- stylua: ignore
   self.highlights = {
-    active = self:create_hl( self.options.tabs_color.active, 'active'),
-    inactive = self:create_hl( self.options.tabs_color.inactive, 'inactive'),
+    active = self:create_hl(self.options.tabs_color.active, 'active'),
+    inactive = self:create_hl(self.options.tabs_color.inactive, 'inactive'),
   }
 end
 

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -34,6 +34,13 @@ local mode_to_highlight = {
   ['TERMINAL'] = '_terminal',
 }
 
+--- Get highlight suffix for current mode, or inactive if not focused
+---@return string mode_suffix
+function M.get_mode_suffix()
+  local mode = require('lualine.utils.mode').get_mode()
+  return mode_to_highlight[mode] or '_normal'
+end
+
 --- determine if an highlight exist and isn't cleared
 ---@param highlight_name string
 ---@return boolean whether hl_group was defined with highlight_name
@@ -222,8 +229,7 @@ local function append_mode(highlight_group, is_focused)
   if is_focused == false then
     return highlight_group .. '_inactive'
   end
-  local mode = require('lualine.utils.mode').get_mode()
-  return highlight_group .. (mode_to_highlight[mode] or '_normal')
+  return highlight_group .. M.get_mode_suffix()
 end
 
 -- Helper function for create component highlight
@@ -392,13 +398,13 @@ function M.component_format_highlight(highlight, is_focused)
     local color = highlight.fn { section = highlight.section } or {}
     local hl_name = highlight.name
     if type(color) == 'string' then
-      M.highlight(hl_name, nil, nil, nil, color)
-      return '%#' .. hl_name .. '#'
+      M.highlight(hl_name .. M.get_mode_suffix(), nil, nil, nil, color)
+      return '%#' .. hl_name .. M.get_mode_suffix() .. '#'
     elseif type(color) == 'table' then
       if not highlight.no_default and not (color.fg and color.bg) then
         hl_name = append_mode(highlight.name, is_focused)
         color =
-          get_default_component_color(hl_name, append_mode(''):sub(2), highlight.section, color, highlight.options)
+          get_default_component_color(hl_name, M.get_mode_suffix():sub(2), highlight.section, color, highlight.options)
       end
       M.highlight(hl_name, color.fg, color.bg, color.gui, color.link)
       return '%#' .. hl_name .. '#', color


### PR DESCRIPTION
I noticed that the color of the buffers component wasn't changing with the other components in my lualine setup as I changed modes:<br>
![lua-tabs-before](https://user-images.githubusercontent.com/38540736/219361911-b8b72e35-eaa1-4504-b571-b165b16a5766.PNG)

I attempted to use a function to change the color based on mode, but encountered this visual issue where only part of the background of the active buffer changed:<br>
![lualine-before-with-fn](https://user-images.githubusercontent.com/38540736/219362010-246749b1-8fb8-4910-8ee3-3f2951d956df.PNG)

I fixed that issue in highlight.lua, and added a `get_mode_suffix` function to simplify retrieving the mode suffix from outside of the highlight module.

I also added a `use_mode_colors` option to the buffers, tabs, and windows components (false by default), which automatically sets the colors of those components. 

How it looks now:<br>
![lualine-after](https://user-images.githubusercontent.com/38540736/219363468-37d326ff-42c5-49c2-a5ee-bb0e427c961e.PNG)
