### PR TITLE
Render terminal mode as insert

### DIFF
--- a/lua/lualine/themes/powerline.lua
+++ b/lua/lualine/themes/powerline.lua
@@ -19,7 +19,7 @@ local Colors = {
   gray10         = '#f0f0f0',
 }
 
-return {
+local M = {
   normal = {
     a = { fg = Colors.darkestgreen, bg = Colors.brightgreen, gui = 'bold' },
     b = { fg = Colors.gray10, bg = Colors.gray5 },
@@ -38,3 +38,7 @@ return {
     c = { bg = Colors.gray1, fg = Colors.gray5 },
   },
 }
+
+M.terminal = M.insert
+
+return M

--- a/lua/lualine/themes/powerline_dark.lua
+++ b/lua/lualine/themes/powerline_dark.lua
@@ -22,7 +22,7 @@ local colors = {
   cyan         = '#00DFFF',
 }
 
-return {
+local M = {
   normal = {
     a = { bg = colors.neon, fg = colors.black, gui = 'bold' },
     b = { bg = colors.gray, fg = colors.white },
@@ -54,3 +54,7 @@ return {
     c = { bg = colors.darkgray, fg = colors.gray },
   },
 }
+
+M.terminal = M.insert
+
+return M


### PR DESCRIPTION
I think, that terminal mode should be rendered as insert if insert mode is activated. This patch sets insert mode  properties to terminal mode in powerline theme. I can update other themes it this behavior is ok. 

![term_insert](https://user-images.githubusercontent.com/33599/223957293-448bcb43-3747-438e-be83-407e9badc32c.png)
![term_normal](https://user-images.githubusercontent.com/33599/223957307-6e299eb3-8cdd-4840-b3ed-7d4bdc9aa521.png)
