### PR TITLE
Add overseer extension to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,7 @@ extensions = {'quickfix'}
 - nerdtree
 - nvim-dap-ui
 - nvim-tree
+- overseer
 - quickfix
 - symbols-outline
 - toggleterm


### PR DESCRIPTION
Overseer is a task runner plugin: https://github.com/stevearc/overseer.nvim

I was looking to see if lualine had an overseer extension so was digging around in the extensions dir and found it there, but it wasn't listed in the README, so just a short 1 line commit to update the text