### PR TITLE
feat: add dap server status to nvim-dap-ui extension

### DIFF
--- a/lua/lualine/extensions/nvim-dap-ui.lua
+++ b/lua/lualine/extensions/nvim-dap-ui.lua
@@ -1,9 +1,27 @@
 -- MIT license, see LICENSE for more details.
 -- Extension for nvim-dap-ui
+
+local dap_lua, _ = pcall(require, 'dap')
+
+local function dap_status()
+  if not dap_lua then
+    return ''
+  end
+
+  local status = require('dap').status()
+
+  if status == nil or status == '' then
+    return ''
+  else
+    return 'DAP: ' .. status
+  end
+end
+
 local M = {}
 
 M.sections = {
   lualine_a = { { 'filename', file_status = false } },
+  lualine_x = { dap_status },
 }
 
 M.filetypes = {


### PR DESCRIPTION
The current status of a DAP debug server can be retrieved via `require('dap').status()`. It's helpful always to see it on screen while debugging. So here it is added to lualine.

Here is what it'll look like _(bottom right)_:

![2023-03-10_08-16-57](https://user-images.githubusercontent.com/2261839/224339700-c542793c-26dd-4623-9a9a-b07fe1c07e85.jpg)

### Non-PR Specific Question
The [`nvim-dap-ui`](https://github.com/rcarriga/nvim-dap-ui) plugin filetypes are all the windows around the main code window in the screenshot. I have a question about this. You can only see the dap status if you are focused on one of those filetypes. Is it possible to update a lualine status at any time? The [`nvim-dap`](https://github.com/mfussenegger/nvim-dap) plugin has an event system you can hook into. So, if it's possible to update `lualine_x` we could call the update method each time a DAP server event fires. How that fits into this extension code, I'm not sure.
