### PR TITLE
Allow specifying theme as function

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -251,6 +251,9 @@ local function setup_theme()
     elseif type(theme_name) == 'table' then
       -- use the provided theme as-is
       return config.options.theme
+    elseif type(theme_name) == 'function' then
+      -- call function and use returned (dynamic) theme as-is
+      return config.options.theme()
     end
     if theme_name ~= 'auto' then
       notify_theme_error(theme_name)


### PR DESCRIPTION
Use case: I have a custom theme that dynamically adjusts to the OS' dark/light mode. If the theme can be a function, that function can return the proper color values each time it is called.

Alternative: Create a `lua/lualine/themes/mytheme.lua` next to `lua/lualine/myconfig/mytheme.lua` which only does `require("myconfig.mytheme").lualine_theme()` and configure `lualine.setup({options = {theme = "mytheme"}})`.  This is IMHO more convoluted and a lot less readable/understandable.