### PR TITLE
drop support for nvim-0.5, 0.6 (BREAKING)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - flavor: nvim-0.5
-            runner: ubuntu-20.04
-            os: linux
-            nvim_version: v0.5.0
-          - flavor: nvim-0.6
-            runner: ubuntu-20.04
-            os: linux
-            nvim_version: v0.6.0
           - flavor: nvim-0.7
             runner: ubuntu-20.04
             os: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
             runner: ubuntu-20.04
             os: linux
             nvim_version: v0.8.0
+          - flavor: nvim-0.9
+            runner: ubuntu-20.04
+            os: linux
+            nvim_version: v0.9.0
           - flavor: nvim-nightly
             runner: ubuntu-20.04
             os: linux

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 
 A blazing fast and easy to configure Neovim statusline written in Lua.
 
-`lualine.nvim` requires Neovim >= 0.5.
+`lualine.nvim` requires Neovim >= 0.7.
+
+For previous versoins of neovim please use compatability tags for example
+compat-nvim-0.5
 
 ## Contributing
 

--- a/lua/lualine/components/diagnostics/config.lua
+++ b/lua/lualine/components/diagnostics/config.lua
@@ -18,7 +18,7 @@ M.options = {
   colored = true,
   update_in_insert = false,
   always_visible = false,
-  sources = { vim.fn.has('nvim-0.6') == 1 and 'nvim_diagnostic' or 'nvim_lsp', 'coc' },
+  sources = { 'nvim_diagnostic',  'coc' },
   sections = { 'error', 'warn', 'info', 'hint' },
 }
 

--- a/lua/lualine/components/diagnostics/sources.lua
+++ b/lua/lualine/components/diagnostics/sources.lua
@@ -6,28 +6,17 @@ local M = {}
 M.sources = {
   nvim_lsp = function()
     local error_count, warning_count, info_count, hint_count
-    if vim.fn.has('nvim-0.6') == 1 then
-      -- On nvim 0.6+ use vim.diagnostic to get lsp generated diagnostic count.
-      local diagnostics = vim.diagnostic.get(0)
-      local count = { 0, 0, 0, 0 }
-      for _, diagnostic in ipairs(diagnostics) do
-        if vim.startswith(vim.diagnostic.get_namespace(diagnostic.namespace).name, 'vim.lsp') then
-          count[diagnostic.severity] = count[diagnostic.severity] + 1
-        end
+    local diagnostics = vim.diagnostic.get(0)
+    local count = { 0, 0, 0, 0 }
+    for _, diagnostic in ipairs(diagnostics) do
+      if vim.startswith(vim.diagnostic.get_namespace(diagnostic.namespace).name, 'vim.lsp') then
+        count[diagnostic.severity] = count[diagnostic.severity] + 1
       end
-      error_count = count[vim.diagnostic.severity.ERROR]
-      warning_count = count[vim.diagnostic.severity.WARN]
-      info_count = count[vim.diagnostic.severity.INFO]
-      hint_count = count[vim.diagnostic.severity.HINT]
-    else
-      -- On 0.5 use older vim.lsp.diagnostic module.
-      -- Maybe we should phase out support for 0.5 though I haven't yet found a solid reason to.
-      -- Eventually this will be removed when 0.5 is no longer supported.
-      error_count = vim.lsp.diagnostic.get_count(0, 'Error')
-      warning_count = vim.lsp.diagnostic.get_count(0, 'Warning')
-      info_count = vim.lsp.diagnostic.get_count(0, 'Information')
-      hint_count = vim.lsp.diagnostic.get_count(0, 'Hint')
     end
+    error_count = count[vim.diagnostic.severity.ERROR]
+    warning_count = count[vim.diagnostic.severity.WARN]
+    info_count = count[vim.diagnostic.severity.INFO]
+    hint_count = count[vim.diagnostic.severity.HINT]
     return error_count, warning_count, info_count, hint_count
   end,
   nvim_workspace_diagnostic = function()

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -103,12 +103,6 @@ local function apply_configuration(config_table)
       end
     end
   end
-  if config_table.options and config_table.options.globalstatus and vim.fn.has('nvim-0.7') == 0 then
-    modules.utils_notices.add_notice(
-      '### Options.globalstatus\nSorry `globalstatus` option can only be used in neovim 0.7 or higher.\n'
-    )
-    config_table.options.globalstatus = false
-  end
   if vim.fn.has('nvim-0.8') == 0 and (next(config_table.winbar or {}) or next(config_table.inactive_winbar or {})) then
     modules.utils_notices.add_notice('### winbar\nSorry `winbar can only be used in neovim 0.8 or higher.\n')
     config_table.winbar = {}


### PR DESCRIPTION
Users of these versions can still use compatibility tags compat-nvim-0.5 and compat-nvim-0.6 respectively.

BREAKING CHANGE