### PR TITLE
Fix: Quickfix extension and lazy extension

### DIFF
--- a/lua/lualine/extensions/lazy.lua
+++ b/lua/lualine/extensions/lazy.lua
@@ -10,7 +10,7 @@ local M = {}
 M.sections = {
   lualine_a = {
     function()
-      return 'lazy 💤'
+      return 'lazy'
     end,
   },
   lualine_b = {

--- a/lua/lualine/extensions/quickfix.lua
+++ b/lua/lualine/extensions/quickfix.lua
@@ -41,6 +41,6 @@ M.sections = {
   lualine_z = { 'location' },
 }
 
-M.filetypes = { 'qf' }
+M.filetypes = { 'qf', 'replacer' }
 
 return M


### PR DESCRIPTION
- reason for removing the emoji:
![CleanShot 2023-04-02 at 07 58 30](https://user-images.githubusercontent.com/73286100/229334476-a914e2f5-97fe-40fb-b1cd-40a282ce13ac.png)
- replacer.nvim basically also works with the quickfix list, just uses a different filetype for it