### PR TITLE
Fix: `searchcount` error (#1004)

### DIFF
--- a/lua/lualine/components/searchcount.lua
+++ b/lua/lualine/components/searchcount.lua
@@ -20,6 +20,10 @@ function M:update_status()
   end
 
   local result = vim.fn.searchcount { maxcount = self.options.maxcount, timeout = self.options.timeout }
+  if next(result) == nil then
+    return ''
+  end
+
   local denominator = math.min(result.total, result.maxcount)
   return string.format('[%d/%d]', result.current, denominator)
 end


### PR DESCRIPTION
`searchcount.lua` now checks if the resulting table from `vim.fn.searchcount` is empty to avoid the error.