### PR TITLE
Add support for base16-vim alongside nvim-base16

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -54,7 +54,7 @@ But if `g:ayuprefermirage` exists, it will load ayu_mirage instead when
 
 ### base16
 
-This theme will automatically use colors defined by your colorscheme using [RRethy/nvim-base16](https://github.com/RRethy/nvim-base16)] plugin.
+This theme will automatically use colors defined by your colorscheme using [tinted-theming/base16-vim](https://github.com/tinted-theming/base16-vim) or [RRethy/nvim-base16](https://github.com/RRethy/nvim-base16)] plugin.
 The following example is using the `tomorrow-night` colorscheme:
 
 <p>

--- a/lua/lualine/themes/base16.lua
+++ b/lua/lualine/themes/base16.lua
@@ -50,7 +50,8 @@ local function setup_default()
   }
 end
 
-local function setup_base16()
+local function setup_base16_nvim()
+  -- Continue to load nvim-base16
   local loaded, base16 = pcall(require, 'base16-colorscheme')
 
   if not loaded then
@@ -89,4 +90,23 @@ local function setup_base16()
   }
 end
 
-return setup_base16() or setup_default()
+local function setup_base16_vim()
+  -- Check if tinted-theming/base16-vim is already loaded
+  if vim.g.base16_gui00 and vim.g.base16_gui0F then
+    return setup {
+      bg = vim.g.base16_gui01,
+      alt_bg = vim.g.base16_gui02,
+      dark_fg = vim.g.base16_gui03,
+      fg = vim.g.base16_gui04,
+      light_fg = vim.g.base16_gui05,
+      normal = vim.g.base16_gui0D,
+      insert = vim.g.base16_gui0B,
+      visual = vim.g.base16_gui0E,
+      replace = vim.g.base16_gui09,
+    }
+  end
+
+  return nil
+end
+
+return setup_base16_vim() or setup_base16_nvim() or setup_default()


### PR DESCRIPTION
Currently lualine.nvim only supports [nvim-base16](https://github.com/RRethy/nvim-base16), this adds support for [base16-vim](https://github.com/tinted-theming/base16-vim).

[base16-vim](https://github.com/tinted-theming/base16-vim) and [nvim-base16](https://github.com/RRethy/nvim-base16) both use the `base16-` prefix for colorscheme names:
- https://github.com/tinted-theming/base16-vim/tree/main/colors
- https://github.com/RRethy/nvim-base16/tree/master/colors

This causes colorschemes from both plugins to trigger the `lua/lualine/themes/base16.lua`  file, which is why I made the changes in that file.

- Check if a [base16-vim](https://github.com/tinted-theming/base16-vim) colorscheme is active (by testing to see if the first and last colour variables are set). If it is, use the existing global variables, if not then continue to load and setup [nvim-base16](https://github.com/RRethy/nvim-base16).
- Update readme in context of changes

I can add some more context for the [base16-vim](https://github.com/tinted-theming/base16-vim) and [tinted-theming](https://github.com/tinted-theming) if necessary, just let me know.