### PR TITLE
feat: Add harpoon_files component

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,32 @@ sections = {
 }
 ```
 
+#### harpoon_files component options
+
+```lua
+sections = {
+  lualine_a = {
+    {
+      'harpoon_files',
+      show_filename_only = true,   -- Shows shortened relative path when set to false.
+      hide_filename_extension = false,   -- Hide filename extension when set to true.
+
+      max_length = vim.o.columns * 2 / 3, -- Maximum width of harpoon_files component,
+                                          -- it can also be a function that returns
+                                          -- the value of `max_length` dynamically.
+      -- Automatically updates active harpoon file color to match color of other components
+      use_mode_colors = false,
+
+      harpoon_files_color = {
+        -- Same values as the general color option can be used here.
+        active = 'lualine_{section}_normal',     -- Color for active harpoon file.
+        inactive = 'lualine_{section}_inactive', -- Color for inactive harpoon file.
+      },
+    }
+  }
+}
+```
+
 ---
 
 ### Tabline

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ sections = {lualine_a = {'mode'}}
 - `selectioncount` (number of selected characters or lines)
 - `tabs` (shows currently available tabs)
 - `windows` (shows currently available windows)
+- `harpoon_files` (shows currently available harpoon files)
 
 #### Custom components
 

--- a/lua/lualine/components/harpoon_files/harpoon_file.lua
+++ b/lua/lualine/components/harpoon_files/harpoon_file.lua
@@ -1,0 +1,122 @@
+local Harpoon_file = require('lualine.utils.class'):extend()
+
+local modules = require('lualine_require').lazy_require {
+  highlight = 'lualine.highlight',
+  utils = 'lualine.utils.utils',
+}
+
+
+---initialize a new harpoon_file from opts
+---@param opts table
+function Harpoon_file:init(opts)
+  self.infos = opts.infos
+  self.options = opts.options
+  self.highlights = opts.highlights
+  self:get_props()
+end
+
+function Harpoon_file:is_current()
+  return vim.fn.expand("%:f") == self.infos.filename
+end
+
+function Harpoon_file:get_props()
+  self.file = self.infos.filename
+  self.icon = ''
+  if self.options.icons_enabled then
+    local dev
+    local status, _ = pcall(require, 'nvim-web-devicons')
+    if not status then
+      dev, _ = '', ''
+    else
+      dev, _ = require('nvim-web-devicons').get_icon(self.file)
+    end
+    if dev then
+      self.icon = dev .. ' '
+    end
+  end
+end
+
+---returns rendered buffer
+---@return string
+function Harpoon_file:render()
+  local name = self:name()
+  if self.options.fmt then
+    name = self.options.fmt(name or '', self)
+  end
+
+  if self.ellipse then -- show ellipsis
+    name = '...'
+  else
+    name = string.format('%s%s', self.icon, name)
+  end
+  name = Harpoon_file.apply_padding(name, self.options.padding)
+  self.len = vim.fn.strchars(name)
+
+  -- apply highlight
+  local line = modules.highlight.component_format_highlight(self.highlights[(self.current and 'active' or 'inactive')])
+      .. name
+
+  -- apply separators
+  if self.options.self.section < 'x' and not self.first then
+    local sep_before = self:separator_before()
+    line = sep_before .. line
+    self.len = self.len + vim.fn.strchars(sep_before)
+  elseif self.options.self.section >= 'x' and not self.last then
+    local sep_after = self:separator_after()
+    line = line .. sep_after
+    self.len = self.len + vim.fn.strchars(sep_after)
+  end
+  return line
+end
+
+---apply separator before current buffer
+---@return string
+function Harpoon_file:separator_before()
+  if self.current or self.aftercurrent then
+    return '%Z{' .. self.options.section_separators.left .. '}'
+  else
+    return self.options.component_separators.left
+  end
+end
+
+---apply separator after current buffer
+---@return string
+function Harpoon_file:separator_after()
+  if self.current or self.beforecurrent then
+    return '%z{' .. self.options.section_separators.right .. '}'
+  else
+    return self.options.component_separators.right
+  end
+end
+
+---returns name of current buffer after filtering special buffers
+---@return string
+function Harpoon_file:name()
+  if self.file == '' then
+    return '[No Name]'
+  end
+
+  local name
+  if self.options.show_filename_only then
+    name = vim.fn.fnamemodify(self.file, ':t')
+  else
+    name = vim.fn.pathshorten(vim.fn.fnamemodify(self.file, ':p:.'))
+  end
+  if self.options.hide_filename_extension then
+    name = vim.fn.fnamemodify(name, ':r')
+  end
+  return name
+end
+
+---adds spaces to left and right
+function Harpoon_file.apply_padding(str, padding)
+  local l_padding, r_padding = 1, 1
+  if type(padding) == 'number' then
+    l_padding, r_padding = padding, padding
+  elseif type(padding) == 'table' then
+    l_padding, r_padding = padding.left or 0, padding.right or 0
+  end
+  return string.rep(' ', l_padding) .. str .. string.rep(' ', r_padding)
+end
+
+return Harpoon_file

--- a/lua/lualine/components/harpoon_files/init.lua
+++ b/lua/lualine/components/harpoon_files/init.lua
@@ -42,15 +42,15 @@ function M:init(options)
         return get_hl('lualine_' .. options.self.section, true)
       end
       or get_hl('lualine_' .. options.self.section, true)
-  default_options.buffers_color = {
+  default_options.harpoon_files_color = {
     active = default_active,
     inactive = get_hl('lualine_' .. options.self.section, false),
   }
   self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
   if self.options.component_name == 'harpoon_files' then
     self.highlights = {
-      active = self:create_hl(self.options.buffers_color.active, 'active'),
-      inactive = self:create_hl(self.options.buffers_color.inactive, 'inactive'),
+      active = self:create_hl(self.options.harpoon_files_color.active, 'active'),
+      inactive = self:create_hl(self.options.harpoon_files_color.inactive, 'inactive'),
     }
   end
 end

--- a/lua/lualine/components/harpoon_files/init.lua
+++ b/lua/lualine/components/harpoon_files/init.lua
@@ -1,0 +1,191 @@
+local require = require('lualine_require').require
+local Harpoon_file = require('lualine.components.harpoon_files.harpoon_file')
+local M = require('lualine.component'):extend()
+local highlight = require('lualine.highlight')
+local hp_marks = require('harpoon.mark')
+
+local default_options = {
+  show_filename_only = true,
+  hide_filename_extension = false,
+  use_mode_colors = false,
+  max_length = 0,
+  harpoon_files_color = {
+    active = nil,
+    inactive = nil
+  }
+}
+
+-- This function is duplicated in tabs / buffers
+---returns the proper hl for buffer in section. Used for setting default highlights
+---@param section string name of section buffers component is in
+---@param is_active boolean
+---@return string hl name
+local function get_hl(section, is_active)
+  local suffix = is_active and highlight.get_mode_suffix() or '_inactive'
+  local section_redirects = {
+    lualine_x = 'lualine_c',
+    lualine_y = 'lualine_b',
+    lualine_z = 'lualine_a',
+  }
+  if section_redirects[section] then
+    section = highlight.highlight_exists(section .. suffix) and section or section_redirects[section]
+  end
+  return section .. suffix
+end
+
+-- Same init as buffers
+function M:init(options)
+  M.super.init(self, options)
+  -- if use_mode_colors is set, use a function so that the colors update
+  local default_active = options.use_mode_colors
+      and function()
+        return get_hl('lualine_' .. options.self.section, true)
+      end
+      or get_hl('lualine_' .. options.self.section, true)
+  default_options.buffers_color = {
+    active = default_active,
+    inactive = get_hl('lualine_' .. options.self.section, false),
+  }
+  self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
+  if self.options.component_name == 'harpoon_files' then
+    self.highlights = {
+      active = self:create_hl(self.options.buffers_color.active, 'active'),
+      inactive = self:create_hl(self.options.buffers_color.inactive, 'inactive'),
+    }
+  end
+end
+
+function M:new_harpoon_file(file_infos)
+  return Harpoon_file:new {
+    options = self.options,
+    highlights = self.highlights,
+    infos = file_infos
+  }
+end
+
+function M:harpoon_files()
+  local data = {}
+
+  for idx = 1, hp_marks.get_length() do
+    local file_infos = hp_marks.get_marked_file(idx)
+    data[idx] = self:new_harpoon_file(file_infos)
+  end
+
+  return data
+end
+
+function M:update_status()
+  local hp_files = self:harpoon_files()
+
+  -- return empty data if no harpoon_files
+  if hp_files[1] == nil then
+    return {}
+  end
+
+  local current = -2
+
+  -- mark the first, last, current, before current, after current harpoon_files
+  -- for rendering
+  if hp_files[1] then
+    hp_files[1].first = true
+  end
+  if hp_files[#hp_files] then
+    hp_files[#hp_files].last = true
+  end
+  for i, hp_file in ipairs(hp_files) do
+    if hp_file:is_current() then
+      hp_file.current = true
+      current = i
+    end
+  end
+  if hp_files[current - 1] then
+    hp_files[current - 1].beforecurrent = true
+  end
+  if hp_files[current + 1] then
+    hp_files[current + 1].aftercurrent = true
+  end
+
+  local max_length = self.options.max_length
+  if type(max_length) == 'function' then
+    max_length = max_length(self)
+  end
+
+  if max_length == 0 then
+    max_length = math.floor(2 * vim.o.columns / 3)
+  end
+  local total_length
+
+  local data = {}
+
+  -- Current file not in harpoon
+  if current == -2 then
+    current = 1
+  end
+
+  local current_hp_file = hp_files[current]
+  data[#data + 1] = current_hp_file:render()
+  total_length = current_hp_file.len
+
+  local i = 0
+  local before, after
+  while true do
+    i = i + 1
+    before = hp_files[current - i]
+    after = hp_files[current + i]
+    local rendered_before, rendered_after
+    if before == nil and after == nil then
+      break
+    end
+    -- draw left most undrawn buffer if fits in max_length
+    if before then
+      rendered_before = before:render()
+      total_length = total_length + before.len
+      if total_length > max_length then
+        break
+      end
+      table.insert(data, 1, rendered_before)
+    end
+    -- draw right most undrawn buffer if fits in max_length
+    if after then
+      rendered_after = after:render()
+      total_length = total_length + after.len
+      if total_length > max_length then
+        break
+      end
+      data[#data + 1] = rendered_after
+    end
+  end
+  -- draw ellipsis (...) on relevant sides if all buffers don't fit in max_length
+  if total_length > max_length then
+    if before ~= nil then
+      before.ellipse = true
+      before.first = true
+      table.insert(data, 1, before:render())
+    end
+    if after ~= nil then
+      after.ellipse = true
+      after.last = true
+      data[#data + 1] = after:render()
+    end
+  end
+
+  return table.concat(data)
+end
+
+function M:draw()
+  self.status = ''
+  self.applied_separator = ''
+
+  if self.options.cond ~= nil and self.options.cond() ~= true then
+    return self.status
+  end
+  local status = self:update_status()
+  if type(status) == 'string' and #status > 0 then
+    self.status = status
+    self:apply_section_separators()
+    self:apply_separator()
+  end
+  return self.status
+end
+
+return M


### PR DESCRIPTION
## Description

Since I found that feature useful for having better view on marked files, I decided to share it with you.
This pull request adds the `harpoon_files` component feature to the project. This feature shows the files marked by the [ThePrimeagen/harpoon](https://github.com/ThePrimeagen/harpoon) plugin, including inactives and active files. 
The code is inspired by the 'buffers' component, so most of it is duplicated and the logic is the same.

The on click feature is not yet implemented.

## Changes Made

- Added harpoon_files folder with harpoon_file.lua and init.lua in components folder.
- Updated README.md.

## How to use it

Simply use it as you would use other components
```lua
  ...
  sections = {
    lualine_a = { 'mode' },
    lualine_b = { 'harpoon_files' },
    lualine_c = { 'branch', 'diff', 'diagnostics' },
  },
  ...
  ```
  
  Possible options (taken from buffers, see README):       
```lua
show_filename_only = true,
hide_filename_extension = false, 
max_length = vim.o.columns * 2 / 3, 
use_mode_colors = false,
harpoon_files_color = {
        active = 'lualine_section_normal',     -- Color for active harpoon file.
        inactive = 'lualine_section_inactive', -- Color for inactive harpoon 
}
```