### PR TITLE
fix: removed duplicate code

### DIFF
--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -55,7 +55,7 @@ function M:init(options)
       and function()
         return get_hl('lualine_' .. options.self.section, true)
       end
-    or get_hl('lualine_' .. options.self.section, true)
+      or get_hl('lualine_' .. options.self.section, true)
   default_options.buffers_color = {
     active = default_active,
     inactive = get_hl('lualine_' .. options.self.section, false),
@@ -127,11 +127,6 @@ function M:update_status()
     max_length = math.floor(2 * vim.o.columns / 3)
   end
   local total_length
-  for i, buffer in pairs(buffers) do
-    if buffer.current then
-      current = i
-    end
-  end
   -- start drawing from current buffer and draw left and right of it until
   -- all buffers are drawn or max_length has been reached.
   if current == -2 then


### PR DESCRIPTION
Removed duplicate code in components/buffers/init.lua

```lua
  for i, buffer in ipairs(buffers) do
    if buffer:is_current() then
    -- current buffer.current is set to true and current is set to i 
      buffer.current = true
      current = i
    end
  end
  if buffers[current - 1] then
    buffers[current - 1].beforecurrent = true
  end
  if buffers[current + 1] then
    buffers[current + 1].aftercurrent = true
  end

  local max_length = self.options.max_length
  if type(max_length) == 'function' then
    max_length = max_length(self)
  end

  if max_length == 0 then
    max_length = math.floor(2 * vim.o.columns / 3)
  end
  local total_length
  
  -- duplicate, current is set to i if buffer.current is true, same loop
  for i, buffer in pairs(buffers) do
    if buffer.current then
      current = i
    end
  end
```