### PR TITLE
fix: JDT uris breaking lualine when using more than filename

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -86,6 +86,13 @@ M.update_status = function(self)
     data = vim.fn.expand('%:t')
   end
 
+  -- This is to fix JDT (Java Development Tools) URIs by removing the query
+  -- parameters. The remaining data is enough to identify the buffer in the
+  -- window.
+  if vim.startswith(data, "jdt://") then
+    data = string.sub(data, 0, string.find(data, "?") - 1)
+  end
+
   data = modules.utils.stl_escape(data)
 
   if data == '' then


### PR DESCRIPTION
This is another attempt to fix #820 for JDT URIs. I am open to suggestions how this could be improved from a code organization perspective. I am tempted to also add different filename handling for `jdt://` based buffers as well. Because the filename only option doesn't really pick the correct name in my opinion.