### PR TITLE
Fix: count multibyte chars correctly

### DIFF
--- a/lua/lualine/components/selectioncount.lua
+++ b/lua/lualine/components/selectioncount.lua
@@ -1,13 +1,11 @@
 local function selectioncount()
   local mode = vim.fn.mode(true)
-  local line_start, col_start = vim.fn.line('v'), vim.fn.col('v')
-  local line_end, col_end = vim.fn.line('.'), vim.fn.col('.')
-  if mode:match('') then
-    return string.format('%dx%d', math.abs(line_start - line_end) + 1, math.abs(col_start - col_end) + 1)
-  elseif mode:match('V') or line_start ~= line_end then
-    return math.abs(line_start - line_end) + 1
-  elseif mode:match('v') then
-    return math.abs(col_start - col_end) + 1
+  local line_start = vim.fn.line('v')
+  local line_end = vim.fn.line('.')
+  local line_num = tostring(math.abs(line_start - line_end) + 1)
+  local chars_num = tostring(vim.fn.wordcount()['visual_chars'])
+  if mode:match('[vV]') then
+    return line_num .. 'x' .. chars_num
   else
     return ''
   end


### PR DESCRIPTION
# What
SSIA

# Why
This `selectioncount` func didn't count japanese multibyte chars correctly.