### PR TITLE
fix: use proper function to get `nvim-tree` cwd

### DIFF
--- a/lua/lualine/extensions/nvim-tree.lua
+++ b/lua/lualine/extensions/nvim-tree.lua
@@ -1,10 +1,14 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
-local nerdtree = require('lualine.extensions.nerdtree')
+local function get_short_cwd()
+  return vim.fn.fnamemodify(require('nvim-tree.core').get_cwd(), ':~')
+end
 
 local M = {}
 
-M.sections = vim.deepcopy(nerdtree.sections)
+M.sections = {
+  lualine_a = { get_short_cwd },
+}
 
 M.filetypes = { 'NvimTree' }
 


### PR DESCRIPTION
I noticed that `nvim-tree`'s cwd displayed by the extension was not correct when launched with a `path` different from neovim's cwd, e. g.

```lua
require("nvim-tree.api").tree.toggle({ path = vim.fn.expand("%:h") })
```

I applied this simple edit to the `nvim-tree` extension that fixes this issue.