### PR TITLE
fix(selectioncount) wrong sizes with multibyte, widechars and tabs.

### DIFF
--- a/lua/lualine/components/selectioncount.lua
+++ b/lua/lualine/components/selectioncount.lua
@@ -1,13 +1,29 @@
 local function selectioncount()
-  local mode = vim.fn.mode(true)
-  local line_start, col_start = vim.fn.line('v'), vim.fn.col('v')
-  local line_end, col_end = vim.fn.line('.'), vim.fn.col('.')
-  if mode:match('') then
-    return string.format('%dx%d', math.abs(line_start - line_end) + 1, math.abs(col_start - col_end) + 1)
-  elseif mode:match('V') or line_start ~= line_end then
-    return math.abs(line_start - line_end) + 1
-  elseif mode:match('v') then
-    return math.abs(col_start - col_end) + 1
+  local mode = vim.fn.mode()
+  local lines = math.abs(vim.fn.line('v') - vim.fn.line('.')) + 1
+  if mode == 'v' or mode == 'V' then
+    local wc = vim.fn.wordcount()
+    local bytecount, linecount = '', ''
+    if wc.visual_chars ~= wc.visual_bytes then
+      bytecount = string.format('-%d', wc.visual_bytes)
+    end
+    if lines > 1 then
+      linecount = string.format(' / %d', lines)
+    end
+    return string.format('[%d%s%s]', wc.visual_chars, bytecount, linecount)
+  elseif mode == '' then
+    local cols = vim.fn.virtcol('.') - vim.fn.virtcol('v')
+    local line, col
+    if cols >= 0 then
+      line = vim.fn.getline('v')
+      col = vim.fn.charcol('v') - 1
+    else
+      line = vim.fn.getline('.')
+      col = vim.fn.charcol('.') - 1
+      cols = -cols
+    end
+    local char1width = vim.fn.strwidth(vim.fn.strcharpart(line, col, 1))
+    return string.format('[%dx%d]', lines, cols + char1width)
   else
     return ''
   end


### PR DESCRIPTION
The original implementation of the `selectioncount` component had multiple issues (Bug #1012) and only worked with single cell, single byte characters (no tabs).
This implementations fixes the following issues:

* tabs are correctly reported
* wide chars in block selection mode count according to their screen size (1 or 2 cells)
* multibyte utf8 chars report the correct size

As far as I can see, the results are the same as the ones reported by neovim in the cmdline.
The output was modified to include the total chars and bytes for multiple lines (was only reporting lines when more than one line was selected).
The output is shown in brackets.

