### PR TITLE
Location formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,20 @@ sections = {
 }
 ```
 
+#### location component options
+
+```lua
+sections = {
+  lualine_a {
+    {
+      'location',
+      format_string = '%3d:%-2d', -- string that contains two format specifiers
+                                  -- one for the line number, one for the column number
+    }
+  }
+}
+```
+
 #### searchcount component options
 
 ```lua

--- a/lua/lualine/components/location.lua
+++ b/lua/lualine/components/location.lua
@@ -4,7 +4,7 @@
 local M = require('lualine.component'):extend()
 
 local default_options = {
-	format_string = '%3d:%-2d'
+	format = '%3d:%-2d'
 }
 
 function M:init(options)
@@ -15,7 +15,7 @@ end
 function M:update_status()
   local line = vim.fn.line('.')
   local col = vim.fn.virtcol('.')
-  return string.format(self.options.format_string, line, col)
+  return string.format(self.options.format, line, col)
 end	
 
 return M

--- a/lua/lualine/components/location.lua
+++ b/lua/lualine/components/location.lua
@@ -1,9 +1,21 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
-local function location()
-  local line = vim.fn.line('.')
-  local col = vim.fn.virtcol('.')
-  return string.format('%3d:%-2d', line, col)
+
+local M = require('lualine.component'):extend()
+
+local default_options = {
+	format_string = '%3d:%-2d'
+}
+
+function M:init(options)
+	M.super.init(self, options)
+	self.options = vim.tbl_extend('keep', self.options or {}, default_options)
 end
 
-return location
+function M:update_status()
+  local line = vim.fn.line('.')
+  local col = vim.fn.virtcol('.')
+  return string.format(self.options.format_string, line, col)
+end	
+
+return M

--- a/lua/lualine/components/location.lua
+++ b/lua/lualine/components/location.lua
@@ -4,7 +4,7 @@
 local M = require('lualine.component'):extend()
 
 local default_options = {
-	format = '%3d:%-2d'
+	format_string = '%3d:%-2d'
 }
 
 function M:init(options)
@@ -15,7 +15,7 @@ end
 function M:update_status()
   local line = vim.fn.line('.')
   local col = vim.fn.virtcol('.')
-  return string.format(self.options.format, line, col)
+  return string.format(self.options.format_string, line, col)
 end	
 
 return M


### PR DESCRIPTION
Adds a simple component option called `'format_string'` that allows users to specify the format string to be used for displaying the `'location'` component.

To be used like so:
```
sections = {
  lualine_a {
    {
      'location',
      format_string = '%3d:%-2d', -- string that contains two format specifiers
                                  -- one for the line number, one for the column number
    }
  }
}
```