### PR TITLE
feat: texcount

### DIFF
--- a/lua/lualine/extensions/texcount.lua
+++ b/lua/lualine/extensions/texcount.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+M.filetypes = { 'tex' }
+M.sections = require('lualine').get_config().sections
+local orignal_sections = require('lualine').get_config().sections.lualine_x
+M.sections.lualine_x = vim.tbl_extend('keep', { n_words_component }, orignal_sections)
+
+local n_words = '-'
+local function n_words_component()
+  return n_words .. ' words'
+end
+
+local texcount_group = vim.api.nvim_create_augroup('TexCount', { clear = true })
+vim.api.nvim_create_autocmd({ 'BufWritePost', 'BufWinEnter' }, {
+  pattern = '*.tex',
+  group = texcount_group,
+  callback = function()
+    n_words = vim.fn.system('texcount -1 -sum -merge ' .. vim.fn.shellescape(vim.fn.expand('%:p'))):gsub('%s+', '')
+  end,
+})
+
+return M

--- a/lua/lualine/extensions/texcount.lua
+++ b/lua/lualine/extensions/texcount.lua
@@ -1,14 +1,14 @@
 local M = {}
 
-M.filetypes = { 'tex' }
-M.sections = require('lualine').get_config().sections
-local orignal_sections = require('lualine').get_config().sections.lualine_x
-M.sections.lualine_x = vim.tbl_extend('keep', { n_words_component }, orignal_sections)
-
 local n_words = '-'
 local function n_words_component()
   return n_words .. ' words'
 end
+
+M.filetypes = { 'tex' }
+M.sections = require('lualine').get_config().sections
+local orignal_sections = require('lualine').get_config().sections.lualine_x
+M.sections.lualine_x = vim.tbl_extend('keep', { n_words_component }, orignal_sections)
 
 local texcount_group = vim.api.nvim_create_augroup('TexCount', { clear = true })
 vim.api.nvim_create_autocmd({ 'BufWritePost', 'BufWinEnter' }, {

--- a/lua/lualine/extensions/texcount.lua
+++ b/lua/lualine/extensions/texcount.lua
@@ -1,22 +1,37 @@
 local M = {}
 
+-- Set the initial state of n_words to '-'
 local n_words = '-'
+
+-- Define the functions that will be used in the lualine section and autocmd
 local function n_words_component()
   return n_words .. ' words'
 end
 
-M.filetypes = { 'tex' }
-M.sections = require('lualine').get_config().sections
-local orignal_sections = require('lualine').get_config().sections.lualine_x
-M.sections.lualine_x = vim.tbl_extend('keep', { n_words_component }, orignal_sections)
+local function update_n_words()
+  n_words = vim.fn.system('texcount -1 -sum -merge ' .. vim.fn.shellescape(vim.fn.expand('%:p'))):gsub('%s+', '')
+end
 
+-- Copy the original sections
+M.sections = require('lualine').get_config().sections
+
+-- Copy the original lualine_x
+local orignal_lualine_x = require('lualine').get_config().sections.lualine_x
+
+-- Merge a new table containing the new component and the original lualine_x
+M.sections.lualine_x = vim.tbl_extend('keep', { n_words_component }, orignal_lualine_x)
+
+-- Create a autogroup that clears itself
 local texcount_group = vim.api.nvim_create_augroup('TexCount', { clear = true })
+
+-- Create an autocmd that updates the n_words variable when the user opens the .tex file and at every it gets writen
 vim.api.nvim_create_autocmd({ 'BufWritePost', 'BufWinEnter' }, {
   pattern = '*.tex',
   group = texcount_group,
-  callback = function()
-    n_words = vim.fn.system('texcount -1 -sum -merge ' .. vim.fn.shellescape(vim.fn.expand('%:p'))):gsub('%s+', '')
-  end,
+  callback = update_n_words,
 })
+
+-- Set the filetype of the extension
+M.filetypes = { 'tex' }
 
 return M


### PR DESCRIPTION
This pull request adds the a new extension that allows users to expand their `lualine_x` section to have the number of words in the current file displayed. 

This extension works also for tex files that include others.

It uses `texcount` (installed via the [texlive-core](https://archlinux.org/packages/extra/any/texlive-core/) package) under the hood, so be sure to have it installed if you enable this extension.

Here is an example of the extension at work:
![image](https://github.com/nvim-lualine/lualine.nvim/assets/30158492/e7f17fba-7eb6-4fe6-b292-537c53dee3d7)
