### PR TITLE
add buffers filter

### DIFF
--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -28,6 +28,7 @@ local default_options = {
     alternate_file = '#',
     directory = '',
   },
+  buffer_filter = nil,
 }
 
 -- This function is duplicated in tabs
@@ -85,8 +86,10 @@ function M:buffers()
   M.bufpos2nr = {}
   for b = 1, vim.fn.bufnr('$') do
     if vim.fn.buflisted(b) ~= 0 and vim.api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix' then
-      buffers[#buffers + 1] = self:new_buffer(b, #buffers + 1)
-      M.bufpos2nr[#buffers] = b
+      if not self.options.buffer_filter or type(self.options.buffer_filter) == 'function' and self.options.buffer_filter(b) then
+        buffers[#buffers + 1] = self:new_buffer(b, #buffers + 1)
+        M.bufpos2nr[#buffers] = b
+      end
     end
   end
 


### PR DESCRIPTION
I think it will be useful for me to handle my requirement.

I want to show those buffers in the same git root directory. But all the buflisted buffer will be shown in tabline by default. So I dive into the lualine.nvim repo, and I made some changes to make it work.

Maybe it will be slow down, and maybe there is another way to solve this problem.

Thx!

https://github.com/nvim-lualine/lualine.nvim/assets/55801796/4441b5c5-88a7-40e9-bffd-7825d9c23c8d