### PR TITLE
fix: remove CursorMoved refresh events (#886)

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -27,7 +27,7 @@ local refresh_real_curwin
 
 -- The events on which lualine redraws itself
 local default_refresh_events =
-  'WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized,Filetype,CursorMoved,CursorMovedI'
+  'WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized,Filetype'
 if vim.fn.has('nvim-0.7') == 1 then -- utilize ModeChanged event introduced in 0.7
   default_refresh_events = default_refresh_events .. ',ModeChanged'
 end


### PR DESCRIPTION
This reverts https://github.com/nvim-lualine/lualine.nvim/commit/664c688974a7f183f6d6edae70c6aa117dcbd009 and https://github.com/nvim-lualine/lualine.nvim/commit/b87e47e1dee3cf96fc787f24e282ed5b52ed2fd2 which were originally introduced to make lualine refresh more frequently, but also introduced a bug that causes lualine to flicker under certain circumstances, as noted by https://github.com/nvim-lualine/lualine.nvim/issues/886 .