### PR TITLE
fix(#1087): handle searchcount failures

### DIFF
--- a/lua/lualine/components/searchcount.lua
+++ b/lua/lualine/components/searchcount.lua
@@ -19,8 +19,8 @@ function M:update_status()
     return ''
   end
 
-  local result = vim.fn.searchcount { maxcount = self.options.maxcount, timeout = self.options.timeout }
-  if next(result) == nil then
+  local ok, result = pcall(vim.fn.searchcount, { maxcount = self.options.maxcount, timeout = self.options.timeout })
+  if not ok or next(result) == nil then
     return ''
   end
 


### PR DESCRIPTION
fixes #1087

We could alert the user to the failure, however vim does that well enough.

Tested OK:
- [x] valid search - count populated and iterated properly
- [x] invalid search - no count