### PR TITLE
Add ability to format tabs with highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,12 @@ sections = {
         local mod = vim.fn.getbufvar(bufnr, '&mod')
 
         return name .. (mod == 1 and ' +' or '')
+        -- alternatively, return a highlighted table
+        return {
+          {highlight = "%#Visual#", name = bufnr .. ". "},
+          {text = name},
+          {highlight = "%#Visual#", text = (mod == 1 and ' +' or '')},
+        }
       end
     }
   }


### PR DESCRIPTION
This adds a handling of optional `fmt` return value that is a table of `{highlight = "*", name = "*"}` or `{name = "*"}` tables. The primary goal is to have highlights not count to the visible character limit. Without it, attempts to format the tab name with highlights cause nearly immediate ellipsification.

Due to crossbleed in the test setup, a buffers component test was also updated to test through _buffer_ commands. Frankly, when using bufferline, one should forget about tab commands, as the real state of vim windows is hidden and unpredictable.

As an example of a practical outcome, with this it's possible to add colored devicons to a tabs tabline:
<img width="1681" alt="image" src="https://github.com/nvim-lualine/lualine.nvim/assets/314453/7ac73ad0-ef00-4003-92b4-5c7ded906af2">

I am trying to keep this as dumb as possible, since windows and their users are inherently more complex than buffers, leading to various ways to usefully represent them that individual users would know best about.