### PR TITLE
feat(use_mode_colors) add the option to toggle mode colors off for everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ require('lualine').setup {
   options = {
     icons_enabled = true,
     theme = 'auto',
+    use_mode_colors = true,
     component_separators = { left = '', right = ''},
     section_separators = { left = '', right = ''},
     disabled_filetypes = {

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -266,18 +266,16 @@ local function setup_theme()
     return modules.loader.load_theme('gruvbox')
   end
   local theme = get_theme_from_config()
-  if config.options.use_mode_colors ~= nil then
-    if config.options.use_mode_colors == false then
-      theme = {
-        normal = theme.normal,
-        insert = theme.normal,
-        visual = theme.normal,
-        replace = theme.normal,
-        command = theme.normal,
-        terminal = theme.normal,
-        inactive = theme.inactive,
-      }
-    end
+  if config.options.use_mode_colors == false then
+    theme = {
+      normal = theme.normal,
+      insert = theme.normal,
+      visual = theme.normal,
+      replace = theme.normal,
+      command = theme.normal,
+      terminal = theme.normal,
+      inactive = theme.inactive,
+    }
   end
   modules.highlight.create_highlight_groups(theme)
   vim.cmd([[autocmd lualine ColorScheme * lua require'lualine'.setup()

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -266,6 +266,11 @@ local function setup_theme()
     return modules.loader.load_theme('gruvbox')
   end
   local theme = get_theme_from_config()
+  if config.options.use_mode_colors ~= nil then
+     if config.options.use_mode_colors == false then
+       theme = {normal = theme.normal,inactive = theme.inactive} 
+     end
+  end
   modules.highlight.create_highlight_groups(theme)
   vim.cmd([[autocmd lualine ColorScheme * lua require'lualine'.setup()
     autocmd lualine OptionSet background lua require'lualine'.setup()]])

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -267,9 +267,17 @@ local function setup_theme()
   end
   local theme = get_theme_from_config()
   if config.options.use_mode_colors ~= nil then
-     if config.options.use_mode_colors == false then
-       theme = {normal = theme.normal,inactive = theme.inactive} 
-     end
+    if config.options.use_mode_colors == false then
+      theme = {
+        normal = theme.normal,
+        insert = theme.normal,
+        visual = theme.normal,
+        replace = theme.normal,
+        command = theme.normal,
+        terminal = theme.normal,
+        inactive = theme.inactive,
+      }
+    end
   end
   modules.highlight.create_highlight_groups(theme)
   vim.cmd([[autocmd lualine ColorScheme * lua require'lualine'.setup()

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -10,6 +10,7 @@ local config = {
   options = {
     icons_enabled = true,
     theme = 'auto',
+    use_mode_colors = true,
     component_separators = { left = '', right = '' },
     section_separators = { left = '', right = '' },
     disabled_filetypes = {


### PR DESCRIPTION
simply adds `use_mode_colors` to everything not just the `tab` component

i found another bug while making this which is if  `use_mode_colors` is set to true for the `tab` component and the theme doesn't have a highlight for a vim mode (eg. terminal) it fallsback to having no color ?
which is why i had to specify each and every vim mode in the commits