### PR TITLE
Add ctrlspace extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,11 +900,13 @@ extensions = {'quickfix'}
 
 - aerial
 - chadtree
+- ctrlspace
 - fern
 - fugitive
 - fzf
 - lazy
 - man
+- mason
 - mundo
 - neo-tree
 - nerdtree
@@ -915,7 +917,6 @@ extensions = {'quickfix'}
 - symbols-outline
 - toggleterm
 - trouble
-- mason
 
 #### Custom extensions
 

--- a/lua/lualine/extensions/ctrlspace.lua
+++ b/lua/lualine/extensions/ctrlspace.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+M.sections = {
+  lualine_a = { function() return vim.fn['ctrlspace#context#Configuration']().Symbols.CS end },
+  lualine_b = { 'ctrlspace#api#StatuslineModeSegment' },
+  lualine_y = { 'ctrlspace#api#StatuslineTabSegment' },
+  lualine_z = { function() return 'CtrlSpace' end },
+}
+
+M.filetypes = { 'ctrlspace' }
+
+return M


### PR DESCRIPTION
PR resulting from discussion in #1117 

statusline when ctrlspace is activated looks like this:
<img width="1440" alt="image" src="https://github.com/nvim-lualine/lualine.nvim/assets/12605746/622fbc9f-0396-4b44-a4dc-c5070204ae0e">
