### PR TITLE
feat: allow enabling extensions per buftype

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,7 +887,7 @@ You can find a bigger list [here](https://github.com/rockerBOO/awesome-neovim#ta
 ### Extensions
 
 lualine extensions change statusline appearance for a window/buffer with
-specified filetypes.
+specified filetypes or buffertypes.
 
 By default no extensions are loaded to improve performance.
 You can load extensions with:
@@ -926,6 +926,17 @@ You can define your own extensions. If you believe an extension may be useful to
 local my_extension = { sections = { lualine_a = {'mode'} }, filetypes = {'lua'} }
 require('lualine').setup { extensions = { my_extension } }
 ```
+
+To filter by buffer type, for instance, you can apply:
+
+```lua
+local terminal_sec = function() return 'TERMINAL' end
+local my_extension = { sections = { lualine_a = {terminal_sec} }, buftypes = {'terminal'} }
+require('lualine').setup { extensions = { my_extension } }
+```
+
+Note: `filetypes` takes prescedence over `buftypes`. If `filetypes` is present,
+the `buftypes` value is ignored.
 
 ---
 

--- a/tests/spec/lualine_spec.lua
+++ b/tests/spec/lualine_spec.lua
@@ -344,6 +344,147 @@ describe('Lualine', function()
     vim.bo.ft = old_ft
   end)
 
+  describe('can filter extensions based on buftype', function ()
+    it('without filetypes filter being present', function()
+      table.insert(config.extensions, {
+        buftypes = { 'acwrite' },
+        sections = {
+          lualine_a = {
+            function()
+              return 'custom_extension_component'
+            end,
+          },
+        },
+      })
+      local old_buftype = vim.bo.buftype
+      -- We cannot set arbitrary values like ft, must be limited to
+      -- neovim known buf types
+      vim.bo.buftype = 'acwrite'
+      require('lualine').setup(config)
+      statusline:expect([===[
+      highlights = {
+          1: lualine_a_normal = { bg = "#a89984", bold = true, fg = "#282828" }
+          2: lualine_transitional_lualine_a_normal_to_lualine_c_normal = { bg = "#3c3836", fg = "#a89984" }
+          3: lualine_c_normal = { bg = "#3c3836", fg = "#a89984" }
+      }
+      |{1: custom_extension_component }
+      {2:}
+      {3:                                                                                           }|
+      ]===])
+      vim.bo.buftype = old_buftype
+    end)
+
+    it('with empty filetypes filter', function()
+      table.insert(config.extensions, {
+        filetypes = {},
+        buftypes = { 'acwrite' },
+        sections = {
+          lualine_a = {
+            function()
+              return 'custom_extension_component'
+            end,
+          },
+        },
+      })
+      local old_buftype = vim.bo.buftype
+      -- We cannot set arbitrary values like ft, must be limited to
+      -- neovim known buf types
+      vim.bo.buftype = 'acwrite'
+      require('lualine').setup(config)
+      statusline:expect([===[
+      highlights = {
+          1: lualine_a_normal = { bg = "#a89984", bold = true, fg = "#282828" }
+          2: lualine_transitional_lualine_a_normal_to_lualine_c_normal = { bg = "#3c3836", fg = "#a89984" }
+          3: lualine_c_normal = { bg = "#3c3836", fg = "#a89984" }
+      }
+      |{1: custom_extension_component }
+      {2:}
+      {3:                                                                                           }|
+      ]===])
+      vim.bo.buftype = old_buftype
+    end)
+
+    it('and does not apply on different type', function()
+      table.insert(config.extensions, {
+        filetypes = {},
+        buftypes = { 'terminal' },
+        sections = {
+          lualine_a = {
+            function()
+              return 'custom_extension_component'
+            end,
+          },
+        },
+      })
+      local old_buftype = vim.bo.buftype
+      -- We cannot set arbitrary values like ft, must be limited to
+      -- neovim known buf types
+      vim.bo.buftype = 'acwrite'
+      require('lualine').setup(config)
+      statusline:expect([===[
+      highlights = {
+          1: lualine_a_normal = { bg = "#a89984", bold = true, fg = "#282828" }
+          2: lualine_transitional_lualine_a_normal_to_lualine_b_normal = { bg = "#504945", fg = "#a89984" }
+          3: lualine_b_normal = { bg = "#504945", fg = "#ebdbb2" }
+          4: lualine_transitional_lualine_b_normal_to_lualine_c_normal = { bg = "#3c3836", fg = "#504945" }
+          5: lualine_c_normal = { bg = "#3c3836", fg = "#a89984" }
+      }
+      |{1: NORMAL }
+      {2:}
+      {3:  master }
+      {4:}
+      {5: [No Name] }
+      {5:                                                                       }
+      {5:  }
+      {4:}
+      {3: Top }
+      {2:}
+      {1:   1:1  }|
+      ]===])
+      vim.bo.buftype = old_buftype
+    end)
+
+    it('and is only checked after filetypes', function()
+      table.insert(config.extensions, {
+        buftypes = { 'quickfix' },
+        sections = {
+          lualine_a = {
+            function()
+              return 'custom_extension_component'
+            end,
+          },
+        },
+      })
+      table.insert(config.extensions, {
+        filetypes = { 'quickfix' },
+        sections = {
+          lualine_a = {
+            function()
+              return 'should_not_be_present'
+            end,
+          },
+        },
+      })
+
+      local old_buftype = vim.bo.buftype
+      -- We cannot set arbitrary values like ft, must be limited to
+      -- neovim known buf types
+      vim.bo.buftype = 'quickfix'
+      require('lualine').setup(config)
+      statusline:expect([===[
+      highlights = {
+          1: lualine_a_normal = { bg = "#a89984", bold = true, fg = "#282828" }
+          2: lualine_transitional_lualine_a_normal_to_lualine_c_normal = { bg = "#3c3836", fg = "#a89984" }
+          3: lualine_c_normal = { bg = "#3c3836", fg = "#a89984" }
+      }
+      |{1: custom_extension_component }
+      {2:}
+      {3:                                                                                           }|
+      ]===])
+      vim.bo.buftype = old_buftype
+    end)
+  end)
+
   -- TODO: figure put why some of the tablines tests fail in CI
   describe('tabline', function()
     local tab_conf = vim.deepcopy(config)


### PR DESCRIPTION
Context and motivation
======================

I was writing an extension for the special terminal buffer 
and realized in has no ``filetype`` like the quickfix window,
instead filetype is empty and the `buftype` is 'terminal'. 
Currently here is no direct way to set an special bufferline 
for the terminal buffer.

Proposed change
===============

Add a ``buftypes`` table to the extension table, allowing to
filter extensions by buftype; and the corresponding
implementation.

Some basic test cases were added.

Example extension
=================

Example of an extension for terminal buffers:

<details>

<summary>Source code</summary>

```lua
local terminal_extension = {
    sections = {

        lualine_a = { function()
            return 'TERMINAL'
        end },

        lualine_b = {
            function()
                local name = vim.api.nvim_buf_get_name(0)
                local match = string.match(vim.split(name, ' ')[1], 'term:.*:(%a+)')
                return match ~= nil and match or vim.fn.fnamemodify(vim.env.SHELL, ':t')
            end },
        lualine_c = {
            function()
                return vim.b.term_title
            end
        },
        lualine_x = {},
        lualine_y = {

            function()
                local dev, _ = require('nvim-web-devicons').get_icon('zsh')
                return dev
            end
        },
        lualine_z = {},
    },
    buftypes = { 'terminal' },
}
```

</details>

![image](https://github.com/nvim-lualine/lualine.nvim/assets/42856449/870cc966-6c33-499f-9e28-07d295174f26)