### PR TITLE
feat: add option on how to get a devicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ sections = {
       'filetype',
       colored = true,   -- Displays filetype icon in color if set to true
       icon_only = false, -- Display only an icon for filetype
+      get_icon_by = 'filename', -- Method to get devicon ('filetype' or 'filename')
       icon = { align = 'right' }, -- Display filetype icon on the right hand side
       -- icon =    {'X', align='right'}
       -- Icon string ^ in table is ignored in filetype component

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -10,6 +10,7 @@ local M = lualine_require.require('lualine.component'):extend()
 local default_options = {
   colored = true,
   icon_only = false,
+  get_icon_by = 'filename',
 }
 
 function M:init(options)
@@ -31,9 +32,15 @@ function M:apply_icon()
   local icon, icon_highlight_group
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if ok then
-    icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
-    if icon == nil then
+    if self.options.get_icon_by == 'filetype' then
       icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
+    end
+
+    if icon == nil then
+      icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
+      if icon == nil then
+        icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
+      end
     end
 
     if icon == nil and icon_highlight_group == nil then


### PR DESCRIPTION
Within the filetype component, Lualine always gets filetype devicon by file path, and fallback to using filetype only when unsuccessful. This design leads to problems when:
1. Changing the filetype--the accompanying devicon will not be updated, if displayed
2. (More practically) Editing a file with an extension shared across multiple filetypes; a notable example is `.pl` which is used by both Prolog and Perl. Merely checking the file path (`devicons.get_icon(vim.fn.expand('%:t'))`) will always result in Perl's devicon regardless actual filetype

My proposal is to allow user decide how should the devicon be determined with option `get_icon_by`, with valid inputs `'filename'` (traditional behaviour) or `'filetype'` (prioritising `get_icon_by_filetype` over `get_icon`). I'm uncertain if this change should become the default behaviour; feel free to make it so if there's no strong reason.