### PR TITLE
fix: edge case where buffer is added two times to buffers component

### DIFF
--- a/lua/lualine/components/buffers/init.lua
+++ b/lua/lualine/components/buffers/init.lua
@@ -173,6 +173,7 @@ function M:update_status()
       if total_length > max_length then
         break
       end
+      before = buffers[current - i - 1]
       table.insert(data, 1, rendered_before)
     end
     -- draw right most undrawn buffer if fits in max_length


### PR DESCRIPTION
The total length check for the buffers component first checks if it has enough space to add a before before, then adds it and then checks it for buffers after the current one. If that second check fails the before buffer is added a second time to the buffer component, this time as an ellipsis which can lead to confusing behavior and unwanted visual artifacts. This commit fixes this problem.