### PR TITLE
fix(buffers,tabs): calculation of separator length

### DIFF
--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -87,14 +87,18 @@ function Buffer:render()
     .. line
 
   -- apply separators
+  local function sepchars(sep)
+    return vim.fn.strchars(sep:match('^%%[zZ]{(.+)}$') or sep)
+  end
+
   if self.options.self.section < 'x' and not self.first then
     local sep_before = self:separator_before()
     line = sep_before .. line
-    self.len = self.len + vim.fn.strchars(sep_before)
+    self.len = self.len + sepchars(sep_before)
   elseif self.options.self.section >= 'x' and not self.last then
     local sep_after = self:separator_after()
     line = line .. sep_after
-    self.len = self.len + vim.fn.strchars(sep_after)
+    self.len = self.len + sepchars(sep_after)
   end
   return line
 end

--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -132,14 +132,18 @@ function Tab:render()
     .. line
 
   -- apply separators
+  local function sepchars(sep)
+    return vim.fn.strchars(sep:match('^%%[zZ]{(.+)}$') or sep)
+  end
+
   if self.options.self.section < 'x' and not self.first then
     local sep_before = self:separator_before()
     line = sep_before .. line
-    self.len = self.len + vim.fn.strchars(sep_before)
+    self.len = self.len + sepchars(sep_before)
   elseif self.options.self.section >= 'x' and not self.last then
     local sep_after = self:separator_after()
     line = line .. sep_after
-    self.len = self.len + vim.fn.strchars(sep_after)
+    self.len = self.len + sepchars(sep_after)
   end
   return line
 end


### PR DESCRIPTION
When lualine calculates the length of a buffer or tab in the buffers and tabs components, it also adds the length of the surrounding separators. This pull request fixes a problem which occurs when these separators have surrounding special symbols which do not get printed. So far, lualine counts them as normal printable characters, leading to a wrong overall length.