### PR TITLE
Add option tabline_always_visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ require('lualine').setup {
     },
     ignore_focus = {},
     always_divide_middle = true,
+    tabline_always_visible = true,
     globalstatus = false,
     refresh = {
       statusline = 1000,
@@ -368,6 +369,9 @@ options = {
   always_divide_middle = true, -- When set to true, left sections i.e. 'a','b' and 'c'
                                -- can't take over the entire statusline even
                                -- if neither of 'x', 'y' or 'z' are present.
+
+  tabline_always_visible = true, -- When set to false, tabline will be hidden
+                                 -- when there is no more than two tab pages
 
   globalstatus = false,        -- enable global statusline (have a single statusline
                                -- at bottom of neovim instead of one for  every window).

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -479,7 +479,11 @@ local function set_tabline(hide)
       "call v:lua.require'lualine'.refresh({'kind': 'tabpage', 'place': ['tabline'], 'trigger': 'autocmd'})",
       'lualine_tal_refresh'
     )
-    modules.nvim_opts.set('showtabline', 2, { global = true })
+    if config.options.tabline_always_visible then
+      modules.nvim_opts.set('showtabline', 2, { global = true })
+    else
+      modules.nvim_opts.set('showtabline', 1, { global = true })
+    end
     timers.halt_tal_refresh = false
   else
     modules.nvim_opts.restore('tabline', { global = true })

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -24,6 +24,7 @@ local config = {
       tabline = 1000,
       winbar = 1000,
     },
+    tabline_always_visible = true,
   },
   sections = {
     lualine_a = { 'mode' },


### PR DESCRIPTION
#921 
#904 

This pr added an option `tabline_always_visible`, when setting it to `false`, tabline will be hidden if there are less than two tab pages.