### PR TITLE
fix(#820): Illegal character in filename

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -86,8 +86,6 @@ M.update_status = function(self)
     data = vim.fn.expand('%:t')
   end
 
-  data = modules.utils.stl_escape(data)
-
   if data == '' then
     data = self.options.symbols.unnamed
   end
@@ -98,6 +96,8 @@ M.update_status = function(self)
 
     data = shorten_path(data, path_separator, estimated_space_available)
   end
+
+  data = modules.utils.stl_escape(data)
 
   local symbols = {}
   if self.options.file_status then

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -113,8 +113,6 @@ M.update_status = function(self)
     table.insert(symbols, self.options.symbols.newfile)
   end
 
-  data = modules.utils.stl_escape(data)
-
   return data .. (#symbols > 0 and ' ' .. table.concat(symbols, '') or '')
 end
 

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -687,6 +687,27 @@ describe('Filename component', function()
     vim.fn.winwidth:revert()
     vim.fn.expand:revert()
   end)
+
+  it('shortens path with %', function()
+    stub(vim.fn, 'expand')
+    vim.fn.expand.on_call_with('%:p').returns('%dir1/%dir2/%actual_%file')
+    stub(vim.fn, 'winwidth')
+    vim.fn.winwidth.on_call_with(0).returns(100)
+
+    local opts = build_component_opts {
+      component_separators = { left = '', right = '' },
+      padding = 0,
+      file_status = false,
+      path = 2,
+      shorting_target = 90,
+    }
+    vim.cmd(':e test-file.txt')
+    assert_component('filename', opts, '%%/%%/%%actual_%%file')
+
+    vim.cmd(':bdelete!')
+    vim.fn.winwidth:revert()
+    vim.fn.expand:revert()
+  end)
 end)
 
 describe('vim option & variable component', function()


### PR DESCRIPTION
Also ran into this issue with the `jdt://` URLs, as reported in #820. Instead of using JDT-specific workarounds like #1030 and #821, let's fix the root cause.

Given a directory structure like `%dir1/%dir2/%actual_%file'`, the shortening process should eliminate the `%` escaping. It currently shortens it to `%/%/%%actual_%%file'` instead of the correct '%%/%%/%%actual_%%file'. The unescaped `%/` is an illegal char sequence.

To address this, it would make sense to run the escaping after shortening has been completed.