### PR TITLE
fix: flickering don't react to mode changes if a mapping is not done

### DIFF
--- a/lua/lualine/utils/mode.lua
+++ b/lua/lualine/utils/mode.lua
@@ -4,51 +4,68 @@ local Mode = {}
 
 -- stylua: ignore
 Mode.map = {
-  ['n']      = 'NORMAL',
-  ['no']     = 'O-PENDING',
-  ['nov']    = 'O-PENDING',
-  ['noV']    = 'O-PENDING',
-  ['no\22'] = 'O-PENDING',
-  ['niI']    = 'NORMAL',
-  ['niR']    = 'NORMAL',
-  ['niV']    = 'NORMAL',
-  ['nt']     = 'NORMAL',
-  ['ntT']    = 'NORMAL',
-  ['v']      = 'VISUAL',
-  ['vs']     = 'VISUAL',
-  ['V']      = 'V-LINE',
-  ['Vs']     = 'V-LINE',
-  ['\22']   = 'V-BLOCK',
-  ['\22s']  = 'V-BLOCK',
-  ['s']      = 'SELECT',
-  ['S']      = 'S-LINE',
-  ['\19']   = 'S-BLOCK',
-  ['i']      = 'INSERT',
-  ['ic']     = 'INSERT',
-  ['ix']     = 'INSERT',
-  ['R']      = 'REPLACE',
-  ['Rc']     = 'REPLACE',
-  ['Rx']     = 'REPLACE',
-  ['Rv']     = 'V-REPLACE',
-  ['Rvc']    = 'V-REPLACE',
-  ['Rvx']    = 'V-REPLACE',
-  ['c']      = 'COMMAND',
-  ['cv']     = 'EX',
-  ['ce']     = 'EX',
-  ['r']      = 'REPLACE',
-  ['rm']     = 'MORE',
-  ['r?']     = 'CONFIRM',
-  ['!']      = 'SHELL',
-  ['t']      = 'TERMINAL',
+   ['n']     = 'NORMAL',
+   ['no']    = 'O-PENDING',
+   ['nov']   = 'O-PENDING',
+   ['noV']   = 'O-PENDING',
+   ['no\22'] = 'O-PENDING',
+   ['niI']   = 'NORMAL',
+   ['niR']   = 'NORMAL',
+   ['niV']   = 'NORMAL',
+   ['nt']    = 'NORMAL',
+   ['ntT']   = 'NORMAL',
+   ['v']     = 'VISUAL',
+   ['vs']    = 'VISUAL',
+   ['V']     = 'V-LINE',
+   ['Vs']    = 'V-LINE',
+   ['\22']   = 'V-BLOCK',
+   ['\22s']  = 'V-BLOCK',
+   ['s']     = 'SELECT',
+   ['S']     = 'S-LINE',
+   ['\19']   = 'S-BLOCK',
+   ['i']     = 'INSERT',
+   ['ic']    = 'INSERT',
+   ['ix']    = 'INSERT',
+   ['R']     = 'REPLACE',
+   ['Rc']    = 'REPLACE',
+   ['Rx']    = 'REPLACE',
+   ['Rv']    = 'V-REPLACE',
+   ['Rvc']   = 'V-REPLACE',
+   ['Rvx']   = 'V-REPLACE',
+   ['c']     = 'COMMAND',
+   ['cv']    = 'EX',
+   ['ce']    = 'EX',
+   ['r']     = 'REPLACE',
+   ['rm']    = 'MORE',
+   ['r?']    = 'CONFIRM',
+   ['!']     = 'SHELL',
+   ['t']     = 'TERMINAL',
 }
+
+local last_mode = 'NORMAL'
+vim.api.nvim_create_autocmd({ 'CmdlineEnter' }, {
+  pattern = { '*' },
+  callback = function()
+    -- it's 1 when a : command is silent
+    if vim.fn.getcmdscreenpos() ~= 1 then
+      last_mode = Mode.map['c']
+    end
+  end,
+})
 
 ---@return string current mode name
 function Mode.get_mode()
   local mode_code = vim.api.nvim_get_mode().mode
-  if Mode.map[mode_code] == nil then
-    return mode_code
+  local mode = Mode.map[mode_code]
+  -- if a mapping is not done don't react to mode changes
+  if vim.fn.getchar(1) ~= 0 then
+    return last_mode
   end
-  return Mode.map[mode_code]
+  if mode == nil then
+    mode = mode_code
+  end
+  last_mode = mode
+  return mode
 end
 
 return Mode

--- a/lua/lualine/utils/mode.lua
+++ b/lua/lualine/utils/mode.lua
@@ -44,13 +44,13 @@ Mode.map = {
 
 local last_mode = 'NORMAL'
 vim.api.nvim_create_autocmd({ 'CmdlineChanged' }, {
-    pattern = '*',
-    callback = function()
-        if vim.fn.getchar(1) == 0 then
-            require('lualine').refresh()
-            vim.cmd [[ redraws ]]
-        end
-    end,
+  pattern = '*',
+  callback = function()
+    if vim.fn.getchar(1) == 0 then
+      require('lualine').refresh()
+      vim.cmd([[ redraws ]])
+    end
+  end,
 })
 
 ---@return string current mode name

--- a/lua/lualine/utils/mode.lua
+++ b/lua/lualine/utils/mode.lua
@@ -46,9 +46,11 @@ local last_mode = 'NORMAL'
 vim.api.nvim_create_autocmd({ 'CmdlineChanged' }, {
   pattern = '*',
   callback = function()
-    if vim.fn.getchar(1) == 0 then
-      require('lualine').refresh()
-      vim.cmd([[ redraws ]])
+    if last_mode ~= Mode.map['c'] then
+      if vim.fn.getchar(1) == 0 then
+        require('lualine').refresh()
+        vim.cmd([[ redraws ]])
+      end
     end
   end,
 })

--- a/lua/lualine/utils/mode.lua
+++ b/lua/lualine/utils/mode.lua
@@ -43,20 +43,18 @@ Mode.map = {
 }
 
 local last_mode = 'NORMAL'
-vim.api.nvim_create_autocmd({ 'CmdlineEnter' }, {
-  pattern = { '*' },
-  callback = function()
-    -- it's 1 when a : command is silent
-    if vim.fn.getcmdscreenpos() ~= 1 then
-      last_mode = Mode.map['c']
-    end
-  end,
+vim.api.nvim_create_autocmd({ 'CmdlineChanged' }, {
+    pattern = '*',
+    callback = function()
+        if vim.fn.getchar(1) == 0 then
+            require('lualine').refresh()
+            vim.cmd [[ redraws ]]
+        end
+    end,
 })
 
 ---@return string current mode name
 function Mode.get_mode()
-  -- if a mapping is not done don't react to mode changes
-  -- still reacts for command mappings that aren't silent see above
   if vim.fn.getchar(1) ~= 0 then
     return last_mode
   end

--- a/lua/lualine/utils/mode.lua
+++ b/lua/lualine/utils/mode.lua
@@ -4,42 +4,42 @@ local Mode = {}
 
 -- stylua: ignore
 Mode.map = {
-   ['n']     = 'NORMAL',
-   ['no']    = 'O-PENDING',
-   ['nov']   = 'O-PENDING',
-   ['noV']   = 'O-PENDING',
-   ['no\22'] = 'O-PENDING',
-   ['niI']   = 'NORMAL',
-   ['niR']   = 'NORMAL',
-   ['niV']   = 'NORMAL',
-   ['nt']    = 'NORMAL',
-   ['ntT']   = 'NORMAL',
-   ['v']     = 'VISUAL',
-   ['vs']    = 'VISUAL',
-   ['V']     = 'V-LINE',
-   ['Vs']    = 'V-LINE',
-   ['\22']   = 'V-BLOCK',
-   ['\22s']  = 'V-BLOCK',
-   ['s']     = 'SELECT',
-   ['S']     = 'S-LINE',
-   ['\19']   = 'S-BLOCK',
-   ['i']     = 'INSERT',
-   ['ic']    = 'INSERT',
-   ['ix']    = 'INSERT',
-   ['R']     = 'REPLACE',
-   ['Rc']    = 'REPLACE',
-   ['Rx']    = 'REPLACE',
-   ['Rv']    = 'V-REPLACE',
-   ['Rvc']   = 'V-REPLACE',
-   ['Rvx']   = 'V-REPLACE',
-   ['c']     = 'COMMAND',
-   ['cv']    = 'EX',
-   ['ce']    = 'EX',
-   ['r']     = 'REPLACE',
-   ['rm']    = 'MORE',
-   ['r?']    = 'CONFIRM',
-   ['!']     = 'SHELL',
-   ['t']     = 'TERMINAL',
+  ['n']     = 'NORMAL',
+  ['no']    = 'O-PENDING',
+  ['nov']   = 'O-PENDING',
+  ['noV']   = 'O-PENDING',
+  ['no\22'] = 'O-PENDING',
+  ['niI']   = 'NORMAL',
+  ['niR']   = 'NORMAL',
+  ['niV']   = 'NORMAL',
+  ['nt']    = 'NORMAL',
+  ['ntT']   = 'NORMAL',
+  ['v']     = 'VISUAL',
+  ['vs']    = 'VISUAL',
+  ['V']     = 'V-LINE',
+  ['Vs']    = 'V-LINE',
+  ['\22']   = 'V-BLOCK',
+  ['\22s']  = 'V-BLOCK',
+  ['s']     = 'SELECT',
+  ['S']     = 'S-LINE',
+  ['\19']   = 'S-BLOCK',
+  ['i']     = 'INSERT',
+  ['ic']    = 'INSERT',
+  ['ix']    = 'INSERT',
+  ['R']     = 'REPLACE',
+  ['Rc']    = 'REPLACE',
+  ['Rx']    = 'REPLACE',
+  ['Rv']    = 'V-REPLACE',
+  ['Rvc']   = 'V-REPLACE',
+  ['Rvx']   = 'V-REPLACE',
+  ['c']     = 'COMMAND',
+  ['cv']    = 'EX',
+  ['ce']    = 'EX',
+  ['r']     = 'REPLACE',
+  ['rm']    = 'MORE',
+  ['r?']    = 'CONFIRM',
+  ['!']     = 'SHELL',
+  ['t']     = 'TERMINAL',
 }
 
 local last_mode = 'NORMAL'
@@ -55,12 +55,14 @@ vim.api.nvim_create_autocmd({ 'CmdlineEnter' }, {
 
 ---@return string current mode name
 function Mode.get_mode()
-  local mode_code = vim.api.nvim_get_mode().mode
-  local mode = Mode.map[mode_code]
   -- if a mapping is not done don't react to mode changes
+  -- still reacts for command mappings that aren't silent see above
   if vim.fn.getchar(1) ~= 0 then
     return last_mode
   end
+
+  local mode_code = vim.api.nvim_get_mode().mode
+  local mode = Mode.map[mode_code]
   if mode == nil then
     mode = mode_code
   end


### PR DESCRIPTION
This pr makes lualine ignore mode changes when a mapping is not done.
Which removes flicking for mappings that switch to normal mode then back to insert mode command mode then back etc.