### PR TITLE
fix: flicking with noice detect actual_win with autocmds instead of using vim.g.actual_win

### DIFF
--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -99,9 +99,32 @@ function M.define_autocmd(event, pattern, cmd, group)
   end
 end
 
+local focus_update_autocmd = {
+  'CmdlineEnter',
+  'CmdlineLeave',
+  'WinEnter',
+  'WinClosed',
+  'WinNew',
+}
+-- we do this instead of vim.g.actual_win because some ui replacement plugins open a win and take focus then bring focus back causing flicking
+local actual_win = vim.api.nvim_get_current_win()
+vim.api.nvim_create_autocmd(focus_update_autocmd, {
+  pattern = { '*' },
+  callback = function()
+    actual_win = vim.api.nvim_get_current_win()
+  end,
+})
+
+vim.api.nvim_create_autocmd({ 'CmdlineLeave' }, {
+  pattern = { '*' },
+  callback = function()
+    actual_win = vim.api.nvim_get_current_win()
+  end,
+})
+
 -- Check if statusline is on focused window or not
 function M.is_focused()
-  return tonumber(vim.g.actual_curwin) == vim.api.nvim_get_current_win()
+  return actual_win == vim.api.nvim_get_current_win()
 end
 
 --- Check what's the character at pos

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -108,17 +108,27 @@ local focus_update_autocmd = {
 }
 -- we do this instead of vim.g.actual_win because some ui replacement plugins open a win and take focus then bring focus back causing flicking
 local actual_win = vim.api.nvim_get_current_win()
+local focus_update_lock = false
 vim.api.nvim_create_autocmd(focus_update_autocmd, {
   pattern = { '*' },
   callback = function()
-    actual_win = vim.api.nvim_get_current_win()
+    if not focus_update_lock then
+      actual_win = vim.api.nvim_get_current_win()
+    end
   end,
 })
 
 vim.api.nvim_create_autocmd({ 'CmdlineLeave' }, {
   pattern = { '*' },
   callback = function()
-    actual_win = vim.api.nvim_get_current_win()
+    focus_update_lock = true
+  end,
+})
+
+vim.api.nvim_create_autocmd({ 'CmdlineLeave' }, {
+  pattern = { '*' },
+  callback = function()
+    focus_update_lock = false
   end,
 })
 


### PR DESCRIPTION
this pr locks window focus detection between CmdlineEnter and CmdlineLeave.
to prevent loss of focus by ui replacement plugins.
ui plugins usually return the focus back to the current window after half a second causing flickering.

https://github.com/nvim-lualine/lualine.nvim/assets/130783534/ad285103-1848-4b25-a2e9-bf578b8b7e42