### PR TITLE
fix: set option to nil if not cached and set by lualine

### DIFF
--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -90,6 +90,8 @@ function M.restore(name, opts)
         restore_to = ''
       end
       vim.api.nvim_set_option(name, restore_to)
+    else
+      vim.o[name] = nil
     end
   elseif opts.buffer then
     if

--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -91,7 +91,9 @@ function M.restore(name, opts)
       end
       vim.api.nvim_set_option(name, restore_to)
     else
-      vim.o[name] = nil
+      if type(vim.o[name]) == 'string' and vim.o[name]:find('lualine') then
+        vim.o[name] = nil
+      end
     end
   elseif opts.buffer then
     if


### PR DESCRIPTION
https://github.com/nvim-lualine/lualine.nvim/blob/master/lua/lualine.lua#L567
This line doesn't restore the global 'winbar', because lualine never sets the global 'winbar'.
I am not sure why but Goyo's window uses the global winbar option,and lualine not setting global winbar causes the winbar to stay in Goyo.
fixes(https://github.com/nvim-lualine/lualine.nvim/issues/1122)