### PR TITLE
fix: escape filename after it has been shortened

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -86,8 +86,6 @@ M.update_status = function(self)
     data = vim.fn.expand('%:t')
   end
 
-  data = modules.utils.stl_escape(data)
-
   if data == '' then
     data = self.options.symbols.unnamed
   end
@@ -112,6 +110,8 @@ M.update_status = function(self)
   if self.options.newfile_status and is_new_file() then
     table.insert(symbols, self.options.symbols.newfile)
   end
+
+  data = modules.utils.stl_escape(data)
 
   return data .. (#symbols > 0 and ' ' .. table.concat(symbols, '') or '')
 end


### PR DESCRIPTION
When you try to open a file with a long filename that has a `%` at the start of one of the path segments, the percent sign will first get escaped and then the path segment that contains it may get shortened to a single character which "unescapes" the percent sign:
1. Original filename: `aaaaaa/bbbbbb/%cccccc/dddddd/file.txt`
2. Escaped filename: `aaaaaa/bbbbbb/%%cccccc/dddddd/file.txt`
3. Shortened filename: `a/b/%/d/file.txt` instead of `a/b/%%/d/file.txt`

This bug is likely more common than it may first seem. I found it by jumping to a function definition which was in a java library class with a URL-like filename (it started with `jdt://`). There were a few `\` symbols encoded as `%5C` that caused lualine to crash. 