### PR TITLE
make the iceberg dark theme a little more vibrant

### DIFF
--- a/lua/lualine/themes/iceberg_dark.lua
+++ b/lua/lualine/themes/iceberg_dark.lua
@@ -6,7 +6,7 @@
 local colors = {
   color2   = '#161821',
   color3   = '#b4be82',
-  color4   = '#6b7089',
+  color4   = '#c6c8d1',
   color5   = '#2e313f',
   color8   = '#e2a478',
   color9   = '#3e445e',
@@ -26,14 +26,14 @@ return {
     b = { fg = colors.color4, bg = colors.color5 },
   },
   inactive = {
-    c = { fg = colors.color9, bg = colors.color10 },
     a = { fg = colors.color9, bg = colors.color10, gui = 'bold' },
     b = { fg = colors.color9, bg = colors.color10 },
+    c = { fg = colors.color9, bg = colors.color10 },
   },
   normal = {
-    c = { fg = colors.color9, bg = colors.color10 },
     a = { fg = colors.color11, bg = colors.color12, gui = 'bold' },
     b = { fg = colors.color4, bg = colors.color5 },
+    c = { fg = colors.color4, bg = colors.color10 },
   },
   insert = {
     a = { fg = colors.color2, bg = colors.color15, gui = 'bold' },


### PR DESCRIPTION
Before:
<img width="972" alt="Screenshot 2023-12-07 at 4 18 22 PM" src="https://github.com/nvim-lualine/lualine.nvim/assets/29129/fd0abc87-0982-44c4-abe3-60b1d5e9de1d">
<img width="971" alt="Screenshot 2023-12-07 at 4 18 30 PM" src="https://github.com/nvim-lualine/lualine.nvim/assets/29129/9e312070-92dc-4770-98b7-8287b7f1da45">
<img width="971" alt="Screenshot 2023-12-07 at 4 18 37 PM" src="https://github.com/nvim-lualine/lualine.nvim/assets/29129/69622bde-3b33-478c-b8b8-d7d9720448ce">

After:
<img width="970" alt="Screenshot 2023-12-07 at 4 17 29 PM" src="https://github.com/nvim-lualine/lualine.nvim/assets/29129/fc401e4c-113a-454c-9c23-458d02833485">
<img width="971" alt="Screenshot 2023-12-07 at 4 17 42 PM" src="https://github.com/nvim-lualine/lualine.nvim/assets/29129/18d64902-ece6-4e52-8850-c58b9d8ba8e2">
<img width="971" alt="Screenshot 2023-12-07 at 4 17 51 PM" src="https://github.com/nvim-lualine/lualine.nvim/assets/29129/4ea1d7df-7e3e-4404-8c00-81223dbb7486">
