### PR TITLE
fix(themes): update wombat section_b to match lightline original

### DIFF
--- a/lua/lualine/themes/wombat.lua
+++ b/lua/lualine/themes/wombat.lua
@@ -24,7 +24,7 @@ local colors = {
 return {
   normal = {
     a = { fg = colors.base02, bg = colors.blue, gui = 'bold' },
-    b = { fg = colors.base02, bg = colors.base0 },
+    b = { fg = colors.base3, bg = colors.base01 },
     c = { fg = colors.base2, bg = colors.base02 },
   },
   insert = { a = { fg = colors.base02, bg = colors.green, gui = 'bold' } },


### PR DESCRIPTION
I think this was a typo when the theme was first ported.

The current colors make it hard to see the section text.

Refs: https://github.com/itchyny/lightline.vim/blob/master/autoload/lightline/colorscheme/wombat.vim

| | |
| --- | --- |
| Lightline | ![image](https://github.com/nvim-lualine/lualine.nvim/assets/15943089/5185b99e-f614-4615-85a6-890123d9b771) |
| Lualine `master` | ![image](https://github.com/nvim-lualine/lualine.nvim/assets/15943089/ce6c6c1e-e307-48f2-926d-2a0822835161) |
| Lualine this PR | ![image](https://github.com/nvim-lualine/lualine.nvim/assets/15943089/5f38f362-2566-40a4-bc4d-c88e58685914) |
