### PR TITLE
fix: use larger ft icon when coloring applied

### DIFF
--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -40,6 +40,9 @@ function M:apply_icon()
       icon = ''
       icon_highlight_group = 'DevIconDefault'
     end
+    if icon then
+      icon = icon .. ' '
+    end
     if self.options.colored then
       local highlight_color = modules.utils.extract_highlight_colors(icon_highlight_group, 'fg')
       if highlight_color then
@@ -56,7 +59,7 @@ function M:apply_icon()
   else
     ok = vim.fn.exists('*WebDevIconsGetFileTypeSymbol')
     if ok ~= 0 then
-      icon = vim.fn.WebDevIconsGetFileTypeSymbol()
+      icon = vim.fn.WebDevIconsGetFileTypeSymbol() .. ' '
     end
   end
 
@@ -69,7 +72,7 @@ function M:apply_icon()
   elseif type(self.options.icon) == 'table' and self.options.icon.align == 'right' then
     self.status = self.status .. ' ' .. icon
   else
-    self.status = icon .. ' ' .. self.status
+    self.status = icon .. self.status
   end
 end
 


### PR DESCRIPTION
This PR adds a space after the filetype icon *before* the highlight is applied, meaning that the space after the icon will also get the same foreground highlight as the icon itself, allowing the icon to take its proper full width on most (all?) terminal emulators. Users of `vim-devicons` or users who set the icon highlight to `false` will have the same experience as before. Examples:
Before:
![lualinebeforelua](https://github.com/nvim-lualine/lualine.nvim/assets/55766287/3d660f1f-a05d-422e-8df7-674becfb87dc)
After:
![lualineafterlua](https://github.com/nvim-lualine/lualine.nvim/assets/55766287/d453e6e4-1798-415e-a0c4-4c27df40889e)
Before:
![lualinebeforerust](https://github.com/nvim-lualine/lualine.nvim/assets/55766287/30dbe13f-8a98-4a05-affe-cfe41c5e6de4)
After:
![lualineafterrust](https://github.com/nvim-lualine/lualine.nvim/assets/55766287/ee7c7bbc-1900-46d5-8c01-27903342a491)
