### PR TITLE
fix: mismatch between filetype and icon

### DIFF
--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -48,6 +48,8 @@ function Buffer:get_props()
       dev, _ = require('nvim-web-devicons').get_icon('zsh')
     elseif vim.fn.isdirectory(self.file) == 1 then
       dev, _ = self.options.symbols.directory, nil
+    elseif require('nvim-web-devicons').get_icon_by_filetype(vim.bo.filetype) then
+      dev, _ = require('nvim-web-devicons').get_icon_by_filetype(vim.bo.filetype)
     else
       dev, _ = require('nvim-web-devicons').get_icon(self.file, vim.fn.expand('#' .. self.bufnr .. ':e'))
     end

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -48,10 +48,11 @@ function Buffer:get_props()
       dev, _ = require('nvim-web-devicons').get_icon('zsh')
     elseif vim.fn.isdirectory(self.file) == 1 then
       dev, _ = self.options.symbols.directory, nil
-    elseif require('nvim-web-devicons').get_icon_by_filetype(vim.bo.filetype) then
-      dev, _ = require('nvim-web-devicons').get_icon_by_filetype(vim.bo.filetype)
     else
-      dev, _ = require('nvim-web-devicons').get_icon(self.file, vim.fn.expand('#' .. self.bufnr .. ':e'))
+      dev = (
+        require('nvim-web-devicons').get_icon_by_filetype(self.filetype)
+        or require('nvim-web-devicons').get_icon(self.file, vim.fn.expand('#' .. self.bufnr .. ':e'))
+      )
     end
     if dev then
       self.icon = dev .. ' '

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -29,11 +29,14 @@ function M:apply_icon()
   end
 
   local icon, icon_highlight_group
+  local iconft, icon_highlight_groupft
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if ok then
-    icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
-    if icon == nil then
-      icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
+    icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
+    iconft, icon_highlight_groupft = devicons.get_icon_by_filetype(vim.bo.filetype)
+    if iconft ~= nil then
+      icon = iconft
+      icon_highlight_group = icon_highlight_groupft
     end
 
     if icon == nil and icon_highlight_group == nil then

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -31,9 +31,9 @@ function M:apply_icon()
   local icon, icon_highlight_group
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if ok then
-    icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
+    icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
     if icon == nil then
-      icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
+      icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
     end
 
     if icon == nil and icon_highlight_group == nil then


### PR DESCRIPTION
same extension is used for multiple filetypes, but devicon has matched by extension first. 
This PR matches the icon to the filetype first.
Before:
![2024-01-29-21-11-03](https://github.com/nvim-lualine/lualine.nvim/assets/97871898/3ae98a10-a7d0-4c6f-95da-781efcde1d89)
 After:
![2024-01-29-21-23-35](https://github.com/nvim-lualine/lualine.nvim/assets/97871898/3011b24f-1c2e-4678-8578-1f12df16d86f)
