### PR TITLE
fix: avoid crashing when nvim_win_set_option received invalid status line text

### DIFF
--- a/lua/lualine/utils/nvim_opts.lua
+++ b/lua/lualine/utils/nvim_opts.lua
@@ -74,7 +74,7 @@ function M.set(name, val, opts)
     set_opt(name, val, function(nm)
       return vim.api.nvim_win_get_option(opts.window, nm)
     end, function(nm, vl)
-      vim.api.nvim_win_set_option(opts.window, nm, vl)
+      pcall(function() vim.api.nvim_win_set_option(opts.window, nm, vl) end)
     end, options.window[opts.window])
   end
 end


### PR DESCRIPTION
For some programming language there are some string formatting functions like `String.format("%d", a)` or `printf("%d", a")`. If lualine is combined with `nvim_treesitter#statusline` like the following:

```lua
lualine_x = {
  {
    'nvim_treesitter#statusline',
    type = 'vim_fun'
  },
  'encoding',
  'fileformat',
  'filetype'
},
```

It will sometimes crash when the code has `%` in it.

For example, 

```java
package samples.quickstart.service.pojo;

import java.util.HashMap;

public class StockQuoteService {
    private HashMap map = new HashMap();

    public double getPrice(String symbol) {
        Double price = (Double) map.get(symbol);
        if(price != null){
            return price.doubleValue();
        }
        return 42.00;
    }

    private void writeLog(String symbol, double price) {
        map.put(symbol, new Double(price));
        try {
            Path p = Paths.get("/home", "user", "Document", "templogs", "folde" String.format("%d.log", System.currentTimeMillis()));
        }
    }
}
```

the `%d` should be `%%d` in status line text, but when the line gets too long `nvim_treesitter#statusline` will try to trim the output text and replace with `...`, and something the extra `%` get trimmed off, which may look something like the following

```
...%d.log", System.currentTimeMillis())) -> "folde" String.format("%%d.log", System.currentTimeMillis())
```

and this would throw. (this trigger may differ for different screen widths)

one cheap solution is to wrap `vim.api.nvim_win_set_option` with `pcall`. another solution would be to make sure `vim.api.nvim_win_set_option` is never called with a single `%`.