### PR TITLE
Fix: the refresh delay issue when setting `<cmd>w<CR>` in keymap

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -27,7 +27,7 @@ local refresh_real_curwin
 
 -- The events on which lualine redraws itself
 local default_refresh_events =
-  'WinEnter,BufEnter,SessionLoadPost,FileChangedShellPost,VimResized,Filetype,CursorMoved,CursorMovedI,ModeChanged'
+  'WinEnter,BufEnter,BufWritePost,SessionLoadPost,FileChangedShellPost,VimResized,Filetype,CursorMoved,CursorMovedI,ModeChanged'
 -- Helper for apply_transitional_separators()
 --- finds first applied highlight group after str_checked in status
 ---@param status string : unprocessed statusline string


### PR DESCRIPTION
There was no `BufWritePost` in the previous redraw event, resulting in "modified" icon not being refreshed in time when using `<cmd>write<CR>` in keymap. By adding this event, this problem was fixed.