### PR TITLE
Wombat theme: Fix B section background

### DIFF
--- a/lua/lualine/themes/wombat.lua
+++ b/lua/lualine/themes/wombat.lua
@@ -24,7 +24,7 @@ local colors = {
 return {
   normal = {
     a = { fg = colors.base02, bg = colors.blue, gui = 'bold' },
-    b = { fg = colors.base02, bg = colors.base0 },
+    b = { fg = colors.base02, bg = colors.base00 },
     c = { fg = colors.base2, bg = colors.base02 },
   },
   insert = { a = { fg = colors.base02, bg = colors.green, gui = 'bold' } },


### PR DESCRIPTION
I'm not sure if this is a typo, but having `#808080` as background for sections `B` and `Y` looks weird and not at all like in the screenshots.

Setting it to `#666666` looks better and more true to the screenshots.