### PR TITLE
fix: mason extension lazy loading

### DIFF
--- a/lua/lualine/extensions/mason.lua
+++ b/lua/lualine/extensions/mason.lua
@@ -1,8 +1,11 @@
 -- lualine extension for mason.nvim
 
-local ok, mason_registry = pcall(require, 'mason-registry')
-if not ok then
-  return ''
+local mason_registry
+local function maybe_set_registry()
+  local ok, registry = pcall(require, 'mason-registry')
+  if ok then
+    mason_registry = registry
+  end
 end
 
 local M = {}
@@ -15,6 +18,7 @@ M.sections = {
   },
   lualine_b = {
     function()
+      maybe_set_registry()
       return 'Installed: ' .. #mason_registry.get_installed_packages() .. '/' .. #mason_registry.get_all_package_specs()
     end,
   },


### PR DESCRIPTION
Fixed mason extension to only load mason-registry when the lualine section is
displayed (on 'mason' filetype). This prevents loading mason when lualine is
loaded.
