### PR TITLE
feat: align output of searchcount component with neovim default

### DIFF
--- a/lua/lualine/components/searchcount.lua
+++ b/lua/lualine/components/searchcount.lua
@@ -24,8 +24,17 @@ function M:update_status()
     return ''
   end
 
-  local denominator = math.min(result.total, result.maxcount)
-  return string.format('[%d/%d]', result.current, denominator)
+  if result.incomplete == 0 then
+    return string.format('[%d/%d]', result.current, result.total)
+  elseif result.incomplete == 1 then
+    return '[?/??]'
+  elseif result.incomplete == 2 then
+    if result.current <= result.maxcount then
+      return string.format('[%d/>%d]', result.current, result.maxcount)
+    else
+      return string.format('[>%d/>%d]', result.maxcount, result.maxcount)
+    end
+  end
 end
 
 return M


### PR DESCRIPTION
Neovim's default formatting for indicating the search result position, from `:h search-commands`:

```
  [1/5]         Cursor is on first of 5 matches.
  [1/>99]       Cursor is on first of more than 99 matches.
  [>99/>99]     Cursor is after 99 match of more than 99 matches.
  [?/??]        Unknown how many matches exists, generating the
                statistics was aborted because of search timeout.
```

Meaning of result.incomplete, from `:h searchcount()`:

```
  0: search was fully completed
  1: recomputing was timed out
  2: max count exceeded
```