### PR TITLE
Allow customizing the file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ sections = {
                                -- 3: Absolute path, with tilde as the home directory
                                -- 4: Filename and parent dir, with tilde as the home directory
 
+      custom_shortener = nil   -- hook enabling custom post-processes path
       shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                -- for other components. (terrible name, any suggestions?)
       symbols = {

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -667,7 +667,6 @@ Component specific options             These are options that are available on
                                    -- 3: Absolute path, with tilde as the home directory
                                    -- 4: Filename and parent dir, with tilde as the home directory
     
-	  custom_shortener = nil   -- hook enabling custom post-processes path
           shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                    -- for other components. (terrible name, any suggestions?)
           symbols = {

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -657,6 +657,7 @@ Component specific options             These are options that are available on
                                    -- 3: Absolute path, with tilde as the home directory
                                    -- 4: Filename and parent dir, with tilde as the home directory
     
+	  custom_shortener = nil   -- hook enabling custom post-processes path
           shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                    -- for other components. (terrible name, any suggestions?)
           symbols = {

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -16,6 +16,7 @@ local default_options = {
   file_status = true,
   newfile_status = false,
   path = 0,
+  custom_shortener = nil,
   shorting_target = 40,
 }
 
@@ -90,6 +91,10 @@ M.update_status = function(self)
 
   if data == '' then
     data = self.options.symbols.unnamed
+  end
+
+  if self.options.custom_shortener then
+    data = self.options.custom_shortener(data, path_separator)
   end
 
   if self.options.shorting_target ~= 0 then


### PR DESCRIPTION
Usage example:
`some-long/path/to/the/OneDrive - Company/folder/file`
could get replaced by
`D/folder/file`
which is particularly useful if `~/D` symlinks to the OneDrive dir.