### PR TITLE
fix: prioritize user config for extensions on windows

### DIFF
--- a/lua/lualine_require.lua
+++ b/lua/lualine_require.lua
@@ -54,16 +54,17 @@ function M.require(module)
   end
 
   pattern_path = table.concat { 'lua/', module:gsub('%.', '/'), '.lua' }
-  local paths = vim.api.nvim_get_runtime_file(pattern_path, false)
+  local paths = vim.api.nvim_get_runtime_file(pattern_path, true)
   if #paths <= 0 then
     pattern_path = table.concat { 'lua/', module:gsub('%.', '/'), '/init.lua' }
-    paths = vim.api.nvim_get_runtime_file(pattern_path, false)
+    paths = vim.api.nvim_get_runtime_file(pattern_path, true)
   end
   if #paths > 0 then
     -- put entries from user config path in front
     local user_config_path = vim.fn.stdpath('config')
     table.sort(paths, function(a, b)
-      return vim.startswith(a, user_config_path) or not vim.startswith(b, user_config_path)
+      local pattern = table.concat { user_config_path, M.sep }
+      return string.match(a, pattern) or not string.match(b, pattern)
     end)
     local mod_result = dofile(paths[1])
     package.loaded[module] = mod_result


### PR DESCRIPTION
Fixes the second part of: #1213

The same logic fixed in (#1214) is duplicated in the lualine_require module, which appears to be used internally for loading things like extensions.

On windows, user defined extensions that overwrite the builtin similarly cannot be loaded due to the same string matching issue. In addition, the number of queried runtime files is always less-than or equal to 1 due to the `all` parameter for `nvim_get_runtime_file` being set to false. Making it impossible to sort the list of files and prioritize ones within the users config path `vim.fn.stdpath("config")`.