### PR TITLE
fix: Display all active LSPs as comma separated string

### DIFF
--- a/examples/evil_lualine.lua
+++ b/examples/evil_lualine.lua
@@ -158,19 +158,19 @@ ins_left {
 ins_left {
   -- Lsp server name .
   function()
-    local msg = 'No Active Lsp'
-    local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
-    local clients = vim.lsp.get_active_clients()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local clients = vim.lsp.get_clients { bufnr = bufnr }
+
     if next(clients) == nil then
-      return msg
+      return 'No Active Lsp'
     end
+
+    local active_lsps = {}
     for _, client in ipairs(clients) do
-      local filetypes = client.config.filetypes
-      if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
-        return client.name
-      end
+      table.insert(active_lsps, client.name)
     end
-    return msg
+
+    return table.concat(active_lsps, ', ')
   end,
   icon = ' LSP:',
   color = { fg = '#ffffff', gui = 'bold' },


### PR DESCRIPTION
evil_example.lua was showing just one of the active LSPs. Now all active LSPs will be presented as comma separated string.

Some deprecated functions are not used anymore.