### PR TITLE
feat: add recording events to refresh events

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -27,7 +27,7 @@ local refresh_real_curwin
 
 -- The events on which lualine redraws itself
 local default_refresh_events =
-  'WinEnter,BufEnter,BufWritePost,SessionLoadPost,FileChangedShellPost,VimResized,Filetype,CursorMoved,CursorMovedI,ModeChanged'
+  'WinEnter,BufEnter,BufWritePost,SessionLoadPost,FileChangedShellPost,VimResized,Filetype,CursorMoved,CursorMovedI,ModeChanged,RecordingEnter,RecordingLeave'
 -- Helper for apply_transitional_separators()
 --- finds first applied highlight group after str_checked in status
 ---@param status string : unprocessed statusline string


### PR DESCRIPTION
I'd like to add the events `RecordingEnter` and `RecordingLeave` to the default refresh events.

This is useful for cases where the recording register (e.g., `vim.fn.reg_recording()`) is displayed in lualine. Currently, lualine has to wait until the next refresh which causes a delay. Adding the events `RecordingEnter` and `RecordingLeave` immediately triggers an update for a better experience.

For example, [noice.nvim](https://github.com/folke/noice.nvim) does this with the following snippet from its README.

```lua
{
  require('noice').api.status.mode.get,
  cond = require('noice').api.status.mode.has,
  color = { fg = '#ff9e64' },
}
```

This could also be accomplished manually via:

```lua
local rec_msg = ''
vim.api.nvim_create_autocmd({ 'RecordingEnter', 'RecordingLeave' }, {
  group = vim.api.nvim_create_augroup('LualineRecordingSection', { clear = true }),
  callback = function(e)
    if e.event == 'RecordingLeave' then
      rec_msg = ''
    else
      rec_msg = 'recording @' .. vim.fn.reg_recording()
    end
  end,
})
```
and with the lualine section:
```
{
  function()
    return rec_msg
  end,
  color = { fg = '#ff9e64' },
}
```