### PR TITLE
feat: Add BOM indicator to encoding component

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,20 @@ sections = {
 }
 ```
 
+#### encoding component options
+
+```lua
+sections = {
+  lualine_a = {
+    {
+      'encoding',
+      -- Show '[BOM]' when the file has a byte-order mark
+        show_bomb = false,
+    }
+  }
+}
+```
+
 #### searchcount component options
 
 ```lua

--- a/lua/lualine/components/encoding.lua
+++ b/lua/lualine/components/encoding.lua
@@ -1,7 +1,27 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
-local function encoding()
+local lualine_require = require('lualine_require')
+local M = lualine_require.require('lualine.component'):extend()
+
+local default_options = {
+  -- Show '[BOM]' when the file has a byte-order mark
+  show_bomb = false,
+}
+
+function M:init(options)
+  M.super.init(self, options)
+  self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
+end
+
+function M:update_status()
+  local show_bomb = self.options.show_bomb
+
   local result = vim.opt.fileencoding:get()
+
+  if not show_bomb then
+    return result
+  end
+
   if vim.opt.bomb:get() then
     result = result .. ' [BOM]'
   end
@@ -9,4 +29,4 @@ local function encoding()
   return result
 end
 
-return encoding
+return M

--- a/lua/lualine/components/encoding.lua
+++ b/lua/lualine/components/encoding.lua
@@ -1,7 +1,12 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
 local function encoding()
-  return vim.opt.fileencoding:get()
+  local result = vim.opt.fileencoding:get()
+  if vim.opt.bomb:get() then
+    result = result .. ' [BOM]'
+  end
+
+  return result
 end
 
 return encoding

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -242,6 +242,37 @@ describe('Encoding component', function()
     vim.cmd('bd!')
     os.remove(tmp_path)
   end)
+  it('works with BOM and default config', function()
+    local opts = build_component_opts {
+      component_separators = { left = '', right = '' },
+      padding = 0,
+    }
+    local tmp_path = 'tmp.txt'
+    local tmp_fp = io.open(tmp_path, 'w')
+    tmp_fp:write('test file')
+    tmp_fp:close()
+    vim.cmd('e ' .. tmp_path)
+    vim.cmd('set bomb')
+    assert_component('encoding', opts, 'utf-8')
+    vim.cmd('bd!')
+    os.remove(tmp_path)
+  end)
+  it('works with BOM and option enabled', function()
+    local opts = build_component_opts {
+      component_separators = { left = '', right = '' },
+      padding = 0,
+      show_bomb = true
+    }
+    local tmp_path = 'tmp.txt'
+    local tmp_fp = io.open(tmp_path, 'w')
+    tmp_fp:write('test file')
+    tmp_fp:close()
+    vim.cmd('e ' .. tmp_path)
+    vim.cmd('set bomb')
+    assert_component('encoding', opts, 'utf-8 [BOM]')
+    vim.cmd('bd!')
+    os.remove(tmp_path)
+  end)
 end)
 
 describe('Fileformat component', function()


### PR DESCRIPTION
Inspired by vim-airline, it adds `[BOM]` to the encoding if the file uses byte-order mark