### PR TITLE
`branch` supports `oil` now

### DIFF
--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -74,12 +74,15 @@ function M.find_git_dir(dir_path)
     return git_dir
   end
 
-  local oil_exists, oil = pcall(require, 'oil')
-
   -- get file dir so we can search from that dir
   local file_dir = dir_path or vim.fn.expand('%:p:h')
-  if vim.bo.filetype == 'oil' and oil_exists then
-    file_dir = vim.fn.fnamemodify(oil.get_current_dir(), ':p:h')
+
+  local oil_exists, oil = pcall(require, 'oil')
+  if oil_exists then
+    local ok, dir = pcall(oil.get_current_dir)
+    if ok and dir and dir ~= '' then
+      file_dir = vim.fn.fnamemodify(dir, ":p:h")
+    end
   end
 
   -- extract correct file dir from terminals

--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -74,8 +74,13 @@ function M.find_git_dir(dir_path)
     return git_dir
   end
 
+  local oil_exists, oil = pcall(require, 'oil')
+
   -- get file dir so we can search from that dir
   local file_dir = dir_path or vim.fn.expand('%:p:h')
+  if vim.bo.filetype == 'oil' and oil_exists then
+    file_dir = vim.fn.fnamemodify(oil.get_current_dir(), ':p:h')
+  end
 
   -- extract correct file dir from terminals
   if file_dir and file_dir:match('term://.*') then

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -69,56 +69,21 @@ end
 M.update_status = function(self)
   local path_separator = package.config:sub(1, 1)
   local data
-
-  local oil_ok, oil = pcall(require, 'oil')
-  local oil_enabled = oil_ok and vim.bo.filetype == 'oil'
-
-  local function oil_format(arg)
-    return vim.fn.fnamemodify(oil.get_current_dir(), arg)
-  end
-
   if self.options.path == 1 then
     -- relative path
-    local arg = ':~:.'
-    data = vim.fn.expand('%' .. arg)
-
-    if oil_enabled then
-      data = oil_format(arg)
-    end
+    data = vim.fn.expand('%:~:.')
   elseif self.options.path == 2 then
     -- absolute path
-    local arg = ':p'
-    data = vim.fn.expand('%' .. arg)
-
-    if oil_enabled then
-      data = oil_format(arg)
-    end
+    data = vim.fn.expand('%:p')
   elseif self.options.path == 3 then
     -- absolute path, with tilde
-    local arg = ':p:~'
-    data = vim.fn.expand('%' .. arg)
-
-    if oil_enabled then
-      data = oil_format(arg)
-    end
+    data = vim.fn.expand('%:p:~')
   elseif self.options.path == 4 then
     -- filename and immediate parent
-    local arg = ':p:~'
-    local path = vim.fn.expand('%' .. arg)
-
-    if oil_enabled then
-      path = oil_format(arg)
-    end
-
-    data = filename_and_parent(path, path_separator)
+    data = filename_and_parent(vim.fn.expand('%:p:~'), path_separator)
   else
     -- just filename
-    local arg = ':t'
-    data = vim.fn.expand('%' .. arg)
-
-    if oil_enabled then
-      data = oil_format(arg)
-    end
+    data = vim.fn.expand('%:t')
   end
 
   if data == '' then

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -69,21 +69,56 @@ end
 M.update_status = function(self)
   local path_separator = package.config:sub(1, 1)
   local data
+
+  local oil_ok, oil = pcall(require, 'oil')
+  local oil_enabled = oil_ok and vim.bo.filetype == 'oil'
+
+  local function oil_format(arg)
+    return vim.fn.fnamemodify(oil.get_current_dir(), arg)
+  end
+
   if self.options.path == 1 then
     -- relative path
-    data = vim.fn.expand('%:~:.')
+    local arg = ':~:.'
+    data = vim.fn.expand('%' .. arg)
+
+    if oil_enabled then
+      data = oil_format(arg)
+    end
   elseif self.options.path == 2 then
     -- absolute path
-    data = vim.fn.expand('%:p')
+    local arg = ':p'
+    data = vim.fn.expand('%' .. arg)
+
+    if oil_enabled then
+      data = oil_format(arg)
+    end
   elseif self.options.path == 3 then
     -- absolute path, with tilde
-    data = vim.fn.expand('%:p:~')
+    local arg = ':p:~'
+    data = vim.fn.expand('%' .. arg)
+
+    if oil_enabled then
+      data = oil_format(arg)
+    end
   elseif self.options.path == 4 then
     -- filename and immediate parent
-    data = filename_and_parent(vim.fn.expand('%:p:~'), path_separator)
+    local arg = ':p:~'
+    local path = vim.fn.expand('%' .. arg)
+
+    if oil_enabled then
+      path = oil_format(arg)
+    end
+
+    data = filename_and_parent(path, path_separator)
   else
     -- just filename
-    data = vim.fn.expand('%:t')
+    local arg = ':t'
+    data = vim.fn.expand('%' .. arg)
+
+    if oil_enabled then
+      data = oil_format(arg)
+    end
   end
 
   if data == '' then


### PR DESCRIPTION
Hey, so when using oil file manager the branch is empty when viewing an oil buffer, this is because oil has its own path, now this is a small change to make it work, but I don't really like modifying globally the component like this, maybe this project should have some hooks or apis that the user could override, like `get_buffer_dir` ?

The same problem is with `filename` component and the fix is the same to use the oil api get_current_dir, so thats why I think having a global user editable api for directories would be a great option

https://github.com/nvim-lualine/lualine.nvim/issues/1077

https://github.com/nvim-lualine/lualine.nvim/issues/1077#issuecomment-2119754614