### PR TITLE
fix: Location component was showing wrong column with inlay hints.

### DIFF
--- a/lua/lualine/components/location.lua
+++ b/lua/lualine/components/location.lua
@@ -2,7 +2,7 @@
 -- MIT license, see LICENSE for more details.
 local function location()
   local line = vim.fn.line('.')
-  local col = vim.fn.virtcol('.')
+  local col = vim.fn.charcol('.')
   return string.format('%3d:%-2d', line, col)
 end
 


### PR DESCRIPTION
The location component had been previously changed to use
`vim.api.virtcol` (the screen position of the cursor) instead of
`vim.api.col` (the byte position of the cursor), in order to prevent
showing the wrong column when multibyte characters are present.
Unfortunately, the new inlay hints in neovim 0.10 make heavy use of
virtual text, and therefore the column shown in the location component
is often incorrect.

This change fixes it to use `vim.api.charcol`, which correctly handles
variable-width characters without including virtual text.
