### PR TITLE
Deprecated function in example evil_lualine.lua

### DIFF
--- a/examples/evil_lualine.lua
+++ b/examples/evil_lualine.lua
@@ -160,7 +160,7 @@ ins_left {
   function()
     local msg = 'No Active Lsp'
     local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
-    local clients = vim.lsp.get_active_clients()
+    local clients = vim.lsp.get_clients()
     if next(clients) == nil then
       return msg
     end


### PR DESCRIPTION
When using the example of [evil_line.lua](https://github.com/nvim-lualine/lualine.nvim/blob/master/examples/evil_lualine.lua#L163), show the following error:

![remove](https://github.com/nvim-lualine/lualine.nvim/assets/45508933/27b52109-cd18-4969-abf9-643161257ff7)

In neovim 0.12 vim.lsp.get_active_clients() function will be [deprecated](https://neovim.io/doc/user/deprecated.html#vim.lsp.get_active_clients()), vim.lsp.get_clients() solve the problem and works perfectly
