### PR TITLE
fix: Sync filetype component with filetype option

### DIFF
--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -31,10 +31,7 @@ function M:apply_icon()
   local icon, icon_highlight_group
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if ok then
-    icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
-    if icon == nil then
-      icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
-    end
+    icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
 
     if icon == nil and icon_highlight_group == nil then
       icon = ''


### PR DESCRIPTION
- Will automatically change icon for filetype component when vim's filetype option changes

- Idiomatically derive icon for the filetype component from buffer's filetype (instead of deriving from filename first).

- Some icons may change. E.g. markdown files from "" to "", because nvim-web-devicons have different icons for "markdown" (which is derived from filetype) and "md" (which is derived from file extension).