### PR TITLE
Use vim.diagnostic.count instead of get (Feat #1239)

### DIFF
--- a/lua/lualine/components/diagnostics/sources.lua
+++ b/lua/lualine/components/diagnostics/sources.lua
@@ -33,8 +33,19 @@ M.sources = {
       workspace_diag(diag_severity.HINT)
   end,
   nvim_diagnostic = function()
+    local count
+
+    if vim.diagnostic.count ~= nil then -- neovim >= 0.10.0
+      count = vim.diagnostic.count(0)
+      return count[vim.diagnostic.severity.ERROR] or 0,
+        count[vim.diagnostic.severity.WARN] or 0,
+        count[vim.diagnostic.severity.INFO] or 0,
+        count[vim.diagnostic.severity.HINT] or 0
+    end
+
+    -- fallback
     local diagnostics = vim.diagnostic.get(0)
-    local count = { 0, 0, 0, 0 }
+    count = { 0, 0, 0, 0 }
     for _, diagnostic in ipairs(diagnostics) do
       count[diagnostic.severity] = count[diagnostic.severity] + 1
     end


### PR DESCRIPTION
In NeoVim 0.10.0 vim.diagnostic.count() was added and can be used instead of vim.diagnostic.get(). I edited vim.diagnostic.get() to be a fallback, if vim.diagnostic.count() is not available. By using vim.diagnostic.count() we avoid using a loop, which should be a minimal performance improvement.