### PR TITLE
Add new filename path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ sections = {
                                -- 2: Absolute path
                                -- 3: Absolute path, with tilde as the home directory
                                -- 4: Filename and parent dir, with tilde as the home directory
+                               -- 5: Filename or filename and parent dir when there are duplicate filenames open, with tilde as the home directory
 
       shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                -- for other components. (terrible name, any suggestions?)

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -81,6 +81,26 @@ M.update_status = function(self)
   elseif self.options.path == 4 then
     -- filename and immediate parent
     data = filename_and_parent(vim.fn.expand('%:p:~'), path_separator)
+  elseif self.options.path == 5 then
+    -- check for duplicate filenames in current buffers and add parent dir if a duplicate is found
+    local current_filename = vim.fn.expand('%:t')
+    local buffer_list = vim.fn.getbufinfo { buflisted = 1 }
+    local duplicate_found = false
+
+    for _, buf in ipairs(buffer_list) do
+      if buf.name ~= vim.fn.expand('%:p') and vim.fn.fnamemodify(buf.name, ':t') == current_filename then
+        duplicate_found = true
+        break
+      end
+    end
+
+    if duplicate_found then
+      -- add parent directory to distinguish duplicate filenames
+      local parent_dir = vim.fn.fnamemodify(vim.fn.expand('%:p:~'), ':h:t:~')
+      data = parent_dir .. path_separator .. current_filename
+    else
+      data = current_filename
+    end
   else
     -- just filename
     data = vim.fn.expand('%:t')


### PR DESCRIPTION
Thanks for the great plugin!

I was finding it mildly confusing to tell which file I'm in at any given time in a Rust project I've been working on recently due to the presence of many 'mod.rs' files. However, I prefer my status line to be quite minimal, ideally showing only the filename. In this case, I thought it would be helpful to dynamically add the parent directory to the filename component when multiple buffers are open with files of the same name.
As such, I decided to add a new path option to lualine to accomodate this behavior.

**Example:** 
Directory structure:
```bash
src
├── mod.rs
└── parser
    └── mod.rs
```

Relevant lualine config:
```lua
lualine_c = {
     { "filename", path = 5, padding = 1, },
 },
```
With one of the mod.rs files open, lualine will look like this:
![image](https://github.com/user-attachments/assets/238deed6-31e9-4847-89a4-2915dd6da77a)

When opening the other mod.rs file, lualine will now look like this: (for parser/mod.rs)  
![image](https://github.com/user-attachments/assets/a0718169-8456-4120-a94b-9a4655f1cfc7)
And this for src/mod.rs:
![image](https://github.com/user-attachments/assets/fa8f29b7-1f6c-416c-aa7a-d3eb9cdd3af8)

Deleting either buffer will cause the component to revert to showing only the filename again.


