### PR TITLE
Fix broken `lualine-buffers-options` link in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ of windows instead of at bottom.
 #### Buffers
 
 Shows currently open buffers. Like bufferline . See
-[buffers options](#buffers-component-options)
+[buffers component options](#buffers-component-options)
 for all builtin behaviors of buffers component.
 You can use `:LualineBuffersJump` to jump to buffer based on index
 of buffer in buffers component.


### PR DESCRIPTION
I found that the `|lualine-buffers-options|` link in the help page was broken. This commit updates README.md to fix it.