### PR TITLE
Git branch component: Add option to limit the length of the displayed branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,21 @@ These are options that are available on specific components.
 For example, you have option on `diagnostics` component to
 specify what your diagnostic sources will be.
 
+#### branch component options
+
+```lua
+sections = {
+  lualine_a = {
+    {
+      'branch',
+      max_length = 0, -- Maximum displayed characters of the branch name.
+                      -- Takes effect, if the value is larger than 0.
+                      -- Recommended setting: 30.
+    }
+  }
+}
+```
+
 #### buffers component options
 
 ```lua
@@ -608,6 +623,20 @@ sections = {
 }
 ```
 
+#### encoding component options
+
+```lua
+sections = {
+  lualine_a = {
+    {
+      'encoding',
+      -- Show '[BOM]' when the file has a byte-order mark
+        show_bomb = false,
+    }
+  }
+}
+```
+
 #### fileformat component options
 
 ```lua
@@ -665,20 +694,6 @@ sections = {
       icon = { align = 'right' }, -- Display filetype icon on the right hand side
       -- icon =    {'X', align='right'}
       -- Icon string ^ in table is ignored in filetype component
-    }
-  }
-}
-```
-
-#### encoding component options
-
-```lua
-sections = {
-  lualine_a = {
-    {
-      'encoding',
-      -- Show '[BOM]' when the file has a byte-order mark
-        show_bomb = false,
     }
   }
 }

--- a/lua/lualine/components/branch/init.lua
+++ b/lua/lualine/components/branch/init.lua
@@ -13,7 +13,7 @@ M.init = function(self, options)
   if not self.options.icon then
     self.options.icon = '' -- e0a0
   end
-  modules.git_branch.init()
+  modules.git_branch.init(options)
 end
 
 M.update_status = function(_, is_focused)

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -871,4 +871,31 @@ describe('Branch component', function()
     local rev = git('rev-parse --short=6 HEAD'):sub(1, 6)
     assert_component('branch', opts, rev)
   end)
+
+  it('works with max_length option', function()
+    local opts = build_component_opts {
+      component_separators = { left = '', right = '' },
+      icons_enabled = false,
+      padding = 0,
+      max_length = 10,
+    }
+    local branch_comp = helpers.init_component('branch', opts)
+
+    local test = {
+      noseparator = "noseparato…",
+      separated_name = "separated…",
+      separatorafter_threshold = "separatora…",
+      short_name = "short_name",
+    }
+    -- hack to add a hyphenated key
+    test["other-sep-character"] = "other-sep…"
+
+    for input, expected in pairs(test) do
+      git('checkout -b ' .. input)
+      vim.cmd('e k')
+      vim.cmd('bd')
+      vim.cmd('e ' .. file)
+      assert_comp_ins(branch_comp, expected)
+    end
+  end)
 end)


### PR DESCRIPTION
Added a new function that truncates git branch name if the max_length option is set. It also attempts to strip the last incomplete word after the last word separator (i.e. "-", "_").

Demo in tabline with `max_length = 30`:
- First one's straight-forward.
  branch name = `thisisjustonereallylongbranchnamewithoutseparators` =>
  ![image](https://github.com/user-attachments/assets/289045a9-2966-48bf-b892-cb8a65f1e9fa)
- Here, the 30-long substring would contain "inexplica" at the end, but it is stripped.
  branch name = `this-one-contains-an-inexplicably-long-word` =>
  ![image](https://github.com/user-attachments/assets/c88d08ec-2dd9-4d0e-950f-095b1087cdde)

I'm using the following tabline settings:
```lua
  tabline = {
    lualine_a = {
      {
        "tabs",
        -- options
        -- ...
      }
    },
    lualine_b = {
      {
        "branch",
        -- NEW OPTION
        max_length = 30,
      },
      "diff",
    },
  },
```

closes #1289.