### PR TITLE
fix(loader): look for themes on `package.path`

### DIFF
--- a/lua/lualine/utils/loader.lua
+++ b/lua/lualine/utils/loader.lua
@@ -220,8 +220,12 @@ local function load_theme(theme_name)
   end
   local n_files = #files
   if n_files == 0 then
-    -- No match found
-    error(path .. ' Not found')
+    -- No match found on runtimepath. Fall back to package.path
+    local file = assert(
+      package.searchpath('lualine.themes.' .. theme_name, package.path),
+      'Theme ' .. theme_name .. ' not found'
+    )
+    retval = dofile(file)
   elseif n_files == 1 then
     -- when only one is found run that and return it's return value
     retval = dofile(files[1])


### PR DESCRIPTION
Fixes https://github.com/nvim-neorocks/rocks.nvim/issues/536.

When lualine.nvim is installed as a luarocks package[^1], the loader can't find the themes on the runtimepath, because
Neovim doesn't keep the runtimepath and `package.path` in sync.
This PR introduces a fallback search of the `package.path` if a theme can't be found on the runtimepath.

[^1]: luarocks installs packages with a non-flat hierarchy, with `lua` and `lib` directories in a separate tree.