### PR TITLE
feat: add kanagawa_dragon theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -164,6 +164,15 @@ them based you your `background` option.
 <img width='700' src='https://user-images.githubusercontent.com/41551030/108648902-8f31a080-74bc-11eb-9d8e-37a3f41d4c7a.png'/>
 </p>
 
+### kanagawa_dragon
+
+<p>
+<img width='700' src=''/>
+<img width='700' src=''/>
+<img width='700' src=''/>
+<img width='700' src=''/>
+</p>
+
 ### material
 
 <p>

--- a/lua/lualine/themes/kanagawa_dragon.lua
+++ b/lua/lualine/themes/kanagawa_dragon.lua
@@ -1,0 +1,49 @@
+-- inspired by kanagawa dragon theme for nvim
+-- https://github.com/rebelot/kanagawa.nvim
+
+local colors = {
+  dragonBlack = '#0D0C0C',
+  dragonGray = '#A6A69C',
+  dragonLightGray = '#C5C9C5',
+  dragonBackground = '#282727',
+  dragonForeground = '#C8C093',
+  dragonRed = '#C4746E',
+  dragonGreen = '#87A987',
+  dragonYellow = '#C4B28A',
+  dragonBlue = '#8BA4B0',
+  dragonOrange = '#B6927B',
+  inactiveGray = '#625e5a',
+}
+
+local shared_sections = {
+  b = { bg = colors.dragonBackground, fg = colors.dragonLightGray },
+  c = { bg = colors.dragonBackground, fg = colors.dragonLightGray },
+}
+
+return {
+  normal = vim.tbl_extend('force', {
+    a = { bg = colors.dragonGray, fg = colors.dragonBlack, gui = 'bold' },
+  }, shared_sections),
+
+  insert = vim.tbl_extend('force', {
+    a = { bg = colors.dragonRed, fg = colors.dragonBlack, gui = 'bold' },
+  }, shared_sections),
+
+  visual = vim.tbl_extend('force', {
+    a = { bg = colors.dragonOrange, fg = colors.dragonBlack, gui = 'bold' },
+  }, shared_sections),
+
+  replace = vim.tbl_extend('force', {
+    a = { bg = colors.dragonBlue, fg = colors.dragonBlack, gui = 'bold' },
+  }, shared_sections),
+
+  command = vim.tbl_extend('force', {
+    a = { bg = colors.dragonGreen, fg = colors.dragonBlack, gui = 'bold' },
+  }, shared_sections),
+
+  inactive = {
+    a = { bg = colors.inactiveGray, fg = colors.dragonGray, gui = 'bold' },
+    b = { bg = colors.inactiveGray, fg = colors.dragonGray },
+    c = { bg = colors.inactiveGray, fg = colors.dragonGray },
+  },
+}


### PR DESCRIPTION
Added my personal configuration for the [**kanagawa**](https://github.com/rebelot/kanagawa.nvim) dragon theme, since other people might be interested in it.

![Screenshot from 2024-10-14 16-18-42](https://github.com/user-attachments/assets/af576a4e-7abb-46c3-9f1f-9816119837e5)
![Screenshot from 2024-10-14 16-20-17](https://github.com/user-attachments/assets/cb2a7b08-78dc-4824-98f1-384afda3bc74)
![Screenshot from 2024-10-14 16-33-25 (1)](https://github.com/user-attachments/assets/d8685e9c-469a-45ee-9352-ee45093a585a)
![Screenshot from 2024-10-14 16-21-08](https://github.com/user-attachments/assets/8442dc86-5a64-4d7c-9a54-c5af0b8587c0)
![Screenshot from 2024-10-14 16-21-35](https://github.com/user-attachments/assets/3e2d9d00-e480-432d-bfeb-31fb0b38e521)


