### PR TITLE
Fix git_diff custom source bug with auto-session

### DIFF
--- a/lua/lualine/components/diff/git_diff.lua
+++ b/lua/lualine/components/diff/git_diff.lua
@@ -39,7 +39,7 @@ end
 ---error_code = { added = -1, modified = -1, removed = -1 }
 ---@param bufnr number|nil
 function M.get_sign_count(bufnr)
-  if bufnr then
+  if bufnr and not (type(M.src) == 'function') then
     return diff_cache[bufnr]
   end
   if M.src then


### PR DESCRIPTION
- git_diff does not cache git_sign_count into diff_cache when rmagatti/auto-session plugin is used to launch nvim session with multiple open windows.
- This commit makes sure to not use diff_cache value, but instead, uses the custom source to get git sign counts when M.src (custome source for git_diff) is defined.

## Before the fix - notice that git_diff information doesn't show on the inactive buffer windows upon nvim launch, until they get focuses
https://github.com/user-attachments/assets/7be0a74d-5d5b-4e9c-b124-deeaa97a5be1

## With the fix - notice that git_diff information is shown for all buffer windows upoin nvim launch
https://github.com/user-attachments/assets/ea2b82cf-8389-439a-be1a-866e5e19556c

