### PR TITLE
Fixup: fix attr inheritance breaking highlights

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -465,6 +465,7 @@ local function set_tabline(hide)
   timers.halt_tal_refresh = true
   vim.cmd([[augroup lualine_tal_refresh | exe "autocmd!" | augroup END]])
   if not hide and next(config.tabline) ~= nil then
+    modules.highlight.set_hl_to_normal('TabLine')
     vim.loop.timer_start(
       timers.tal_timer,
       0,
@@ -495,6 +496,8 @@ local function set_statusline(hide)
   timers.halt_stl_refresh = true
   vim.cmd([[augroup lualine_stl_refresh | exe "autocmd!" | augroup END]])
   if not hide and (next(config.sections) ~= nil or next(config.inactive_sections) ~= nil) then
+    modules.highlight.set_hl_to_normal('StatusLine')
+    modules.highlight.set_hl_to_normal('StatusLineNC')
     if vim.go.statusline == '' then
       modules.nvim_opts.set('statusline', '%#Normal#', { global = true })
     end
@@ -548,6 +551,8 @@ local function set_winbar(hide)
   timers.halt_wb_refresh = true
   vim.cmd([[augroup lualine_wb_refresh | exe "autocmd!" | augroup END]])
   if not hide and (next(config.winbar) ~= nil or next(config.inactive_winbar) ~= nil) then
+    modules.highlight.set_hl_to_normal('Winbar')
+    modules.highlight.set_hl_to_normal('WinbarNC')
     vim.loop.timer_start(
       timers.wb_timer,
       0,

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -466,6 +466,8 @@ local function set_tabline(hide)
   vim.cmd([[augroup lualine_tal_refresh | exe "autocmd!" | augroup END]])
   if not hide and next(config.tabline) ~= nil then
     modules.highlight.set_hl_to_normal('TabLine')
+    modules.highlight.set_hl_to_normal('TabLineFill')
+    modules.highlight.set_hl_to_normal('TabLineSel')
     vim.loop.timer_start(
       timers.tal_timer,
       0,

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -491,4 +491,15 @@ function M.get_stl_default_hl(focused)
   end
 end
 
+--- set the hl_name group to Normal
+--- used to avoid conflict with hl groups like StatusLine, StatusLineNc...
+--- @param hl_name string
+function M.set_hl_to_normal(hl_name)
+  local normal_color = modules.utils.extract_highlight_colors('Normal', nil)
+  if normal_color.reverse then -- swap
+    normal_color.fg, normal_color.bg = normal_color.bg, normal_color.fg
+  end
+  M.highlight(hl_name, normal_color.fg, normal_color.bg, 'None', nil)
+end
+
 return M


### PR DESCRIPTION
Use colors from Normal highlight-group to set following highlight groups
  - StatusLine
  - StatusLineNC
  - Tabline
  - TabLineFill
  - TabLineSel
  - Winbar
  - WinbarNC

Note: Having default set to Normal group gives us transparency  effect when bg is not chosen
