### PR TITLE
feat(filename): add filename_map option

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ sections = {
                                -- 2: Absolute path
                                -- 3: Absolute path, with tilde as the home directory
                                -- 4: Filename and parent dir, with tilde as the home directory
+      filename_map = nil       -- Add custom transformation to displayed filename
 
       shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                -- for other components. (terrible name, any suggestions?)

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -671,6 +671,7 @@ Component specific options             These are options that are available on
                                    -- 2: Absolute path
                                    -- 3: Absolute path, with tilde as the home directory
                                    -- 4: Filename and parent dir, with tilde as the home directory
+          filename_map = nil       -- Add custom transformation to displayed filename
     
           shorting_target = 40,    -- Shortens path to leave 40 spaces in the window
                                    -- for other components. (terrible name, any suggestions?)

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -17,6 +17,7 @@ local default_options = {
   newfile_status = false,
   path = 0,
   shorting_target = 40,
+  filename_map = nil
 }
 
 local function is_new_file()
@@ -98,6 +99,9 @@ M.update_status = function(self)
   end
 
   data = modules.utils.stl_escape(data)
+  if self.options.filename_map then
+      data = self.options.filename_map(data)
+  end
 
   local symbols = {}
   if self.options.file_status then


### PR DESCRIPTION
This PR adds a possibility to further apply any transform to the `filename`. I find handy especially in temporary buffers (from e.g. codecompanion, git diff, oil...)