### PR TITLE
Add an option to display total line number in the location component

### DIFF
--- a/lua/lualine/components/location.lua
+++ b/lua/lualine/components/location.lua
@@ -1,9 +1,16 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
-local function location()
+local M = require('lualine.component'):extend()
+
+function M:update_status()
   local line = vim.fn.line('.')
   local col = vim.fn.charcol('.')
-  return string.format('%3d:%-2d', line, col)
+  if self.options.total_lines_in_location then
+    local total_line = vim.fn.line('$')
+    return string.format('%3d/%d:%-2d', line, total_line, col)
+  else
+    return string.format('%3d:%-2d', line, col)
+  end
 end
 
-return location
+return M

--- a/lua/lualine/components/location.lua
+++ b/lua/lualine/components/location.lua
@@ -5,9 +5,9 @@ local M = require('lualine.component'):extend()
 function M:update_status()
   local line = vim.fn.line('.')
   local col = vim.fn.charcol('.')
-  if self.options.total_lines_in_location then
-    local total_line = vim.fn.line('$')
-    return string.format('%3d/%d:%-2d', line, total_line, col)
+  if self.options.line_total_in_location then
+    local line_total = vim.fn.line('$')
+    return string.format('%3d/%d:%-2d', line, line_total, col)
   else
     return string.format('%3d:%-2d', line, col)
   end

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -25,6 +25,7 @@ local config = {
       tabline = 100,
       winbar = 100,
     },
+    total_lines_in_location = false,
   },
   sections = {
     lualine_a = { 'mode' },

--- a/lua/lualine/config.lua
+++ b/lua/lualine/config.lua
@@ -25,7 +25,7 @@ local config = {
       tabline = 100,
       winbar = 100,
     },
-    total_lines_in_location = false,
+    line_total_in_location = false,
   },
   sections = {
     lualine_a = { 'mode' },


### PR DESCRIPTION
Adds total_lines_in_location option to display location as `current_line/total_lines:current_col`. Two notes:

1. I modeled `location.lua` off of `fileformat.lua` in order to have access to `self.options`. This may not be the best approach.
2. This PR is **INCOMPLETE**. In particular, it doesn't include docs updates. There might reasonably be a test to write, too. Haven't explored that yet. The motivation for the current PR is to see if the maintainers approve of the approach and solicit any comments.
