### PR TITLE
Fix filetype for Trouble extension

### DIFF
--- a/lua/lualine/extensions/trouble.lua
+++ b/lua/lualine/extensions/trouble.lua
@@ -17,6 +17,6 @@ M.sections = {
   },
 }
 
-M.filetypes = { 'Trouble' }
+M.filetypes = { 'trouble' }
 
 return M


### PR DESCRIPTION
Trouble creates buffers with a file type of `trouble` (lowercase) not `Trouble`.

This PR fixes the Trouble extension to use the lowercase "trouble" filetype.

See: https://github.com/folke/trouble.nvim/blob/46cf952fc115f4c2b98d4e208ed1e2dce08c9bf6/lua/trouble/view/window.lua#L97

Also I verified it myself with `:set filetype?`
![CleanShot 2024-12-08 at 01 30 58@2x](https://github.com/user-attachments/assets/ac40d93a-0456-4cb3-9bea-cc90dec0a311)
