### PR TITLE
Fix tinted-theming/base16-vim support due to rename

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -54,7 +54,7 @@ But if `g:ayuprefermirage` exists, it will load ayu_mirage instead when
 
 ### base16
 
-This theme will automatically use colors defined by your colorscheme using [tinted-theming/base16-vim](https://github.com/tinted-theming/base16-vim) or [RRethy/nvim-base16](https://github.com/RRethy/nvim-base16)] plugin.
+This theme will automatically use colors defined by your colorscheme using [tinted-theming/tinted-vim](https://github.com/tinted-theming/tinted-vim) or [RRethy/nvim-base16](https://github.com/RRethy/nvim-base16)] plugin.
 The following example is using the `tomorrow-night` colorscheme:
 
 <p>

--- a/lua/lualine/themes/base16.lua
+++ b/lua/lualine/themes/base16.lua
@@ -90,23 +90,23 @@ local function setup_base16_nvim()
   }
 end
 
-local function setup_base16_vim()
-  -- Check if tinted-theming/base16-vim is already loaded
-  if vim.g.base16_gui00 and vim.g.base16_gui0F then
+local function setup_tinted_vim()
+  -- Check if tinted-theming/tinted-vim is already loaded
+  if vim.g.tinted_gui00 and vim.g.tinted_gui0F then
     return setup {
-      bg = vim.g.base16_gui01,
-      alt_bg = vim.g.base16_gui02,
-      dark_fg = vim.g.base16_gui03,
-      fg = vim.g.base16_gui04,
-      light_fg = vim.g.base16_gui05,
-      normal = vim.g.base16_gui0D,
-      insert = vim.g.base16_gui0B,
-      visual = vim.g.base16_gui0E,
-      replace = vim.g.base16_gui09,
+      bg = vim.g.tinted_gui01,
+      alt_bg = vim.g.tinted_gui02,
+      dark_fg = vim.g.tinted_gui03,
+      fg = vim.g.tinted_gui04,
+      light_fg = vim.g.tinted_gui05,
+      normal = vim.g.tinted_gui0D,
+      insert = vim.g.tinted_gui0B,
+      visual = vim.g.tinted_gui0E,
+      replace = vim.g.tinted_gui09,
     }
   end
 
   return nil
 end
 
-return setup_base16_vim() or setup_base16_nvim() or setup_default()
+return setup_tinted_vim() or setup_base16_nvim() or setup_default()


### PR DESCRIPTION
The support for `tinted-theming/base16-vim` was broken because `tinted-theming` have renamed that repository to `tinted-theming/tinted-vim`. 

Most importantly, the internal variables for their base16 colorschemes have changed from `base16_gui*` to `tinted_gui*`, which meant that lualine's checking functions had stopped working.

This fixes the `tinted-theming/tinted-vim` detection, renames the setup function to `setup_tinted_vim()`, and fixes the link in the THEMES.md documentation to point to the new repository name.