### PR TITLE
fix: trouble extension wrong filename

### DIFF
--- a/lua/lualine/extensions/trouble.lua
+++ b/lua/lualine/extensions/trouble.lua
@@ -17,6 +17,6 @@ M.sections = {
   },
 }
 
-M.filetypes = { 'Trouble' }
+M.filetypes = { 'trouble' }
 
 return M


### PR DESCRIPTION
I am using trouble and the lualine trouble extension and I noticed it isn't working.
The problem is, the extension uses the wrong filename for the trouble window. It uses "Trouble" with a capital T, but it should be "trouble" with a lowercase t.
This PR fixes that.