### PR TITLE
Add tinted-vim support

### DIFF
--- a/lua/lualine/themes/base16.lua
+++ b/lua/lualine/themes/base16.lua
@@ -91,8 +91,8 @@ local function setup_base16_nvim()
 end
 
 local function setup_base16_vim()
-  -- Check if tinted-theming/base16-vim is already loaded
-  if vim.g.base16_gui00 and vim.g.base16_gui0F then
+  -- Check if tinted-theming/tinted-vim is already loaded
+  if (vim.g.base16_gui00 and vim.g.base16_gui0F) or (vim.g.tinted_gui00 and vim.g.tinted_gui0F) then
     return setup {
       bg = vim.g.base16_gui01,
       alt_bg = vim.g.base16_gui02,


### PR DESCRIPTION
https://github.com/tinted-theming/base16-vim has been renamed to https://github.com/tinted-theming/tinted-vim and the `vim.g.base16_gui0X` variables changed to `vim.g.tinted_gui00`. This PR adds support for the update while still allowing the theme to work for people using an outdated tinted-vim version.

Change happened in this commit: https://github.com/tinted-theming/tinted-vim/commit/14f6ae01a7c8b7af318f575320f9f65d81a7d751#diff-8e4da39bbefb342dbac24c7b8fe153c9e2b12798d48a2ea5a75721d462ed88faR20