### PR TITLE
fix: insert r_padding within final highlight

### DIFF
--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -105,7 +105,13 @@ function M:apply_padding()
     end
   end
   if r_padding then
-    self.status = self.status .. string.rep(' ', r_padding)
+    if self.status:reverse():find('%*%%.*#.*#%%') == 1 then
+      -- When component has changed the highlight at the end
+      -- we will add the padding before the highlight terminates
+      self.status = self.status:sub(1, -3) .. string.rep(' ', r_padding) .. self.status:sub(-2, -1)
+    else
+      self.status = self.status .. string.rep(' ', r_padding)
+    end
   end
 end
 


### PR DESCRIPTION
When a component ends with a custom highlight, any `r_padding` should be added inside that highlight, not after, just like how `l_padding` is added inside a custom starting highlight. This PR takes care of that.

This is required to fully address https://github.com/folke/trouble.nvim/issues/569 (see also https://github.com/folke/trouble.nvim/pull/616 for the fix to trouble.nvim's own part in the issue).

**Before:**
![Screen Shot 2025-01-16 at 16 53 11 PM](https://github.com/user-attachments/assets/c576c962-f3d2-4500-8def-123228b79391)

**After:**
![Screen Shot 2025-01-16 at 17 18 20 PM](https://github.com/user-attachments/assets/8f8179d1-a444-428d-8b30-34bba96dec45)