### PR TITLE
fix: trouble extension. Works on Trouble.nvim v3 and keep backward compatibility.

### DIFF
--- a/lua/lualine/extensions/trouble.lua
+++ b/lua/lualine/extensions/trouble.lua
@@ -1,14 +1,32 @@
 local M = {}
 
-local function get_trouble_mode()
-  local opts = require('trouble.config').options
-
-  local words = vim.split(opts.mode, '[%W]')
+---Format mode, eg: lsp_document_symbols -> Lsp Document Symbols
+---@param mode string
+---@return string
+local function _format_mode(mode)
+  local words = vim.split(mode, '[%W]')
   for i, word in ipairs(words) do
     words[i] = word:sub(1, 1):upper() .. word:sub(2)
   end
 
   return table.concat(words, ' ')
+end
+
+local function get_trouble_mode()
+  local opts = require('trouble.config').options
+  if opts ~= nil and opts.mode ~= nil then
+    return _format_mode(opts.mode)
+  end
+
+  local win = vim.api.nvim_get_current_win()
+  if vim.w[win] ~= nil then
+    local trouble = vim.w[win].trouble
+    if trouble ~= nil and trouble.mode ~= nil then
+      return _format_mode(trouble.mode)
+    end
+  end
+
+  return ''
 end
 
 M.sections = {
@@ -17,6 +35,6 @@ M.sections = {
   },
 }
 
-M.filetypes = { 'Trouble' }
+M.filetypes = { 'trouble', 'Trouble' }
 
 return M


### PR DESCRIPTION
Changes in v3 of [Trouble.nvim](https://github.com/folke/trouble.nvim):
- Filetype changed, `Trouble`  to `trouble`.
- The current window's mode information is stored in the variable: `vim.w[win_id].trouble`.

preview:
<img width="589" alt="image" src="https://github.com/user-attachments/assets/26d2c116-40a6-488f-85b3-4b2ee77d66c5" />
