### PR TITLE
feat: add extension for avante

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,6 +959,7 @@ extensions = {'quickfix'}
 #### Available extensions
 
 - aerial
+- avante
 - chadtree
 - ctrlspace
 - fern

--- a/lua/lualine/extensions/avante.lua
+++ b/lua/lualine/extensions/avante.lua
@@ -1,0 +1,20 @@
+-- MIT license, see LICENSE for more details.
+-- Extension for avante.nvim
+local M = {}
+
+local function ft_info()
+  local ft = vim.opt_local.filetype:get()
+  if ft == 'Avante' then
+    return 'Output'
+  elseif ft == 'AvanteInput' then
+    return require('lualine.utils.mode').get_mode()
+  elseif ft == 'AvanteSelectedFiles' then
+    return 'Total Files: ' .. vim.api.nvim_buf_line_count(0)
+  end
+end
+
+M.sections = { lualine_a = { ft_info } }
+
+M.filetypes = { 'Avante', 'AvanteInput', 'AvanteSelectedFiles' }
+
+return M


### PR DESCRIPTION
Extension to add information for [avante](https://github.com/yetone/avante.nvim) windows.

Particularly useful when not using a global status line as it simplifies the display of the avante sidebar