### PR TITLE
feat: native support for mini.icons

### DIFF
--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -2,6 +2,7 @@ local Buffer = require('lualine.utils.class'):extend()
 
 local modules = require('lualine_require').lazy_require {
   highlight = 'lualine.highlight',
+  icons = 'lualine.icons',
   utils = 'lualine.utils.utils',
 }
 
@@ -34,25 +35,14 @@ function Buffer:get_props()
   self.alternate_file_icon = self:is_alternate() and self.options.symbols.alternate_file or ''
   self.icon = ''
   if self.options.icons_enabled then
-    local dev
-    local status, _ = pcall(require, 'nvim-web-devicons')
-    if not status then
-      dev, _ = '', ''
-    elseif self.filetype == 'TelescopePrompt' then
-      dev, _ = require('nvim-web-devicons').get_icon('telescope')
-    elseif self.filetype == 'fugitive' then
-      dev, _ = require('nvim-web-devicons').get_icon('git')
-    elseif self.filetype == 'vimwiki' then
-      dev, _ = require('nvim-web-devicons').get_icon('markdown')
-    elseif self.buftype == 'terminal' then
-      dev, _ = require('nvim-web-devicons').get_icon('zsh')
-    elseif vim.fn.isdirectory(self.file) == 1 then
-      dev, _ = self.options.symbols.directory, nil
+    local icon
+    if vim.fn.isdirectory(self.file) == 1 then
+      icon = self.options.symbols.directory
     else
-      dev, _ = require('nvim-web-devicons').get_icon(self.file, vim.fn.expand('#' .. self.bufnr .. ':e'))
+      icon = modules.icons.file(self.file, self.bufnr, self.buftype, self.filetype)
     end
-    if dev then
-      self.icon = dev .. ' '
+    if icon then
+      self.icon = icon .. ' '
     end
   end
 end

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -3,6 +3,7 @@
 local lualine_require = require('lualine_require')
 local modules = lualine_require.lazy_require {
   highlight = 'lualine.highlight',
+  icons = 'lualine.icons',
   utils = 'lualine.utils.utils',
 }
 local M = lualine_require.require('lualine.component'):extend()
@@ -28,46 +29,23 @@ function M:apply_icon()
     return
   end
 
-  local icon, icon_highlight_group
-  local ok, devicons = pcall(require, 'nvim-web-devicons')
-  if ok then
-    icon, icon_highlight_group = devicons.get_icon(vim.fn.expand('%:t'))
-    if icon == nil then
-      icon, icon_highlight_group = devicons.get_icon_by_filetype(vim.bo.filetype)
-    end
-
-    if icon == nil and icon_highlight_group == nil then
-      icon = ''
-      icon_highlight_group = 'DevIconDefault'
-    end
-    if icon then
-      icon = icon .. ' '
-    end
-    if self.options.colored then
-      local highlight_color = modules.utils.extract_highlight_colors(icon_highlight_group, 'fg')
-      if highlight_color then
-        local default_highlight = self:get_default_hl()
-        local icon_highlight = self.icon_hl_cache[highlight_color]
-        if not icon_highlight or not modules.highlight.highlight_exists(icon_highlight.name .. '_normal') then
-          icon_highlight = self:create_hl({ fg = highlight_color }, icon_highlight_group)
-          self.icon_hl_cache[highlight_color] = icon_highlight
-        end
-
-        icon = self:format_hl(icon_highlight) .. icon .. default_highlight
-      end
-    end
-  else
-    ok = vim.fn.exists('*WebDevIconsGetFileTypeSymbol')
-    if ok ~= 0 then
-      icon = vim.fn.WebDevIconsGetFileTypeSymbol()
-      if icon then
-        icon = icon .. ' '
-      end
-    end
-  end
-
+  local icon, icon_highlight_group = modules.icons.filetype()
   if not icon then
     return
+  end
+
+  icon = icon .. ' '
+  if self.options.colored and icon_highlight_group then
+    local highlight_color = modules.utils.extract_highlight_colors(icon_highlight_group, 'fg')
+    if highlight_color then
+      local default_highlight = self:get_default_hl()
+      local icon_highlight = self.icon_hl_cache[highlight_color]
+      if not icon_highlight or not modules.highlight.highlight_exists(icon_highlight.name .. '_normal') then
+        icon_highlight = self:create_hl({ fg = highlight_color }, icon_highlight_group)
+        self.icon_hl_cache[highlight_color] = icon_highlight
+      end
+      icon = self:format_hl(icon_highlight) .. icon .. default_highlight
+    end
   end
 
   if self.options.icon_only then

--- a/lua/lualine/icons.lua
+++ b/lua/lualine/icons.lua
@@ -1,0 +1,58 @@
+local M = {}
+
+---@param file string
+---@param bufnr integer
+---@param buftype string
+---@param filetype string
+---@return string|nil
+function M.file(file, bufnr, buftype, filetype)
+  local has_miniicons, miniicons = pcall(require, 'mini.icons')
+  if has_miniicons and _G.MiniIcons then
+    return miniicons.get('file', file)
+  end
+
+  local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
+  if has_devicons then
+    if filetype == 'TelescopePrompt' then
+      return devicons.get_icon('telescope')
+    elseif filetype == 'fugitive' then
+      return devicons.get_icon('git')
+    elseif filetype == 'vimwiki' then
+      return devicons.get_icon('markdown')
+    elseif buftype == 'terminal' then
+      return devicons.get_icon('zsh')
+    else
+      return devicons.get_icon(file, vim.fn.expand('#' .. bufnr .. ':e'))
+    end
+  end
+
+  return nil
+end
+
+---@return string|nil, string|nil
+function M.filetype()
+  local has_miniicons, miniicons = pcall(require, 'mini.icons')
+  if has_miniicons and _G.MiniIcons then
+    return miniicons.get('filetype', vim.bo.filetype)
+  end
+
+  local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
+  if has_devicons then
+    local icon, highlight = devicons.get_icon(vim.fn.expand('%:t'))
+    if not icon then
+      icon, highlight = devicons.get_icon_by_filetype(vim.bo.filetype)
+    end
+    if not icon and not highlight then
+      icon, highlight = '', 'DevIconDefault'
+    end
+    return icon, highlight
+  end
+
+  if vim.fn.exists('*WebDevIconsGetFileTypeSymbol') ~= 0 then
+    return vim.fn.WebDevIconsGetFileTypeSymbol()
+  end
+
+  return nil, nil
+end
+
+return M


### PR DESCRIPTION
## Details

`mini.icons` is an alternative to `nvim-web-devicons` that is getting support from quite a few plugins. This change adds native support for the plugin so users do not need to mock it via `mock_nvim_web_devicons`.

Currently `nvim-web-devicons` is used in the `buffer` and `filetype` components. Created a separate `icons` module to store the icon related logic which now gets used by both of these components.

The logic is to first check if `mini.icons` exists and has been setup, if so for the `buffer` component use `get` with the `file` category, for `filetype` use `get` with the `filetype` category. It may make sense to use the `file` category for both.

From there the fallback to use `nvim-web-devicons` or `vim-devicons` is kept identical.

If this is something you'd prefer not to have I can understand, the `mock_nvim_web_devicons` is not a bad alternative. Only downsides are all the additional highlight groups and additional startup time for `mini.icons`, but both are minor.