### PR TITLE
Buffer component: get icon bugfix (would not load icon for .sh file)

### DIFF
--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -51,11 +51,9 @@ function Buffer:get_props()
     else
       dev, _ = require('nvim-web-devicons').get_icon(self.file, vim.fn.expand('#' .. self.bufnr .. ':e'))
     end
-    
     if dev == nil then
       dev, _ = require('nvim-web-devicons').get_icon_by_filetype(self.filetype)
     end
-    
     if dev then
       self.icon = dev .. ' '
     end

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -49,8 +49,13 @@ function Buffer:get_props()
     elseif vim.fn.isdirectory(self.file) == 1 then
       dev, _ = self.options.symbols.directory, nil
     else
+      dev, _ = require('nvim-web-devicons').get_icon(self.file, vim.fn.expand('#' .. self.bufnr .. ':e'))
+    end
+    
+    if dev == nil then
       dev, _ = require('nvim-web-devicons').get_icon_by_filetype(self.filetype)
     end
+    
     if dev then
       self.icon = dev .. ' '
     end

--- a/lua/lualine/components/buffers/buffer.lua
+++ b/lua/lualine/components/buffers/buffer.lua
@@ -27,8 +27,8 @@ end
 ---setup icons, modified status for buffer
 function Buffer:get_props()
   self.file = modules.utils.stl_escape(vim.api.nvim_buf_get_name(self.bufnr))
-  self.buftype = vim.api.nvim_buf_get_option(self.bufnr, 'buftype')
-  self.filetype = vim.api.nvim_buf_get_option(self.bufnr, 'filetype')
+  self.buftype = vim.bo[self.bufnr].buftype
+  self.filetype = vim.bo[self.bufnr].filetype
   local modified = self.options.show_modified_status and vim.api.nvim_buf_get_option(self.bufnr, 'modified')
   self.modified_icon = modified and self.options.symbols.modified or ''
   self.alternate_file_icon = self:is_alternate() and self.options.symbols.alternate_file or ''
@@ -49,7 +49,7 @@ function Buffer:get_props()
     elseif vim.fn.isdirectory(self.file) == 1 then
       dev, _ = self.options.symbols.directory, nil
     else
-      dev, _ = require('nvim-web-devicons').get_icon(self.file, vim.fn.expand('#' .. self.bufnr .. ':e'))
+      dev, _ = require('nvim-web-devicons').get_icon_by_filetype(self.filetype)
     end
     if dev then
       self.icon = dev .. ' '


### PR DESCRIPTION
Found a bug where for a .sh script, the shell icon would not load in the tabline buffer component.  The previous get_icon method was needlessly complex... unless there is some use I do not understand.  get_icon_by_filetype matches the filetype component implementation

Also got a deprecation warning for vim.api.nvim_buf_get_option, so I updated it to vim.bo