### PR TITLE
Feat: added terminal color for dracula theme

### DIFF
--- a/lua/lualine/themes/dracula.lua
+++ b/lua/lualine/themes/dracula.lua
@@ -10,6 +10,7 @@ local colors = {
   red        = '#ff5555',
   yellow     = '#f1fa8c',
   green      = '#50fa7b',
+  pink       = '#ff79c6',
   white      = '#f8f8f2',
   black      = '#282a36',
 }
@@ -37,6 +38,11 @@ return {
   },
   command = {
     a = { bg = colors.orange, fg = colors.black, gui = 'bold' },
+    b = { bg = colors.lightgray, fg = colors.white },
+    c = { bg = colors.gray, fg = colors.white },
+  },
+  terminal = {
+    a = { bg = colors.pink, fg = colors.black, gui = 'bold' },
     b = { bg = colors.lightgray, fg = colors.white },
     c = { bg = colors.gray, fg = colors.white },
   },


### PR DESCRIPTION
Went with pink since it was the only unused color from the Dracula theme.
![image](https://github.com/user-attachments/assets/8c2f7b41-9a22-46ad-b45d-43860779cc83)
