### PR TITLE
fix: correctly handle git diff paths with spaces

### DIFF
--- a/lua/lualine/components/diff/git_diff.lua
+++ b/lua/lualine/components/diff/git_diff.lua
@@ -92,11 +92,18 @@ function M.update_diff_args()
     return
   end
   M.diff_args = {
-    cmd = string.format(
-      [[git -C %s --no-pager diff --no-color --no-ext-diff -U0 -- %s]],
+    cmd = {
+      'git',
+      '-C',
       vim.fn.expand('%:h'),
-      vim.fn.expand('%:t')
-    ),
+      '--no-pager',
+      'diff',
+      '--no-color',
+      '--no-ext-diff',
+      '-U0',
+      '--',
+      vim.fn.expand('%:t'),
+    },
     on_stdout = function(_, data)
       if next(data) then
         diff_output_cache = vim.list_extend(diff_output_cache, data)


### PR DESCRIPTION
This PR updates the `cmd` passed to `jobstart()` in the diff component to use a list instead of a formatted string. This avoids invoking the shell and prevents issues with paths that contain spaces.

Using a list ensures arguments are passed directly to the executable without shell parsing or the need for escaping, making the command more robust and reliable.