### PR TITLE
fix: update branch_cache on get_branch() call

### DIFF
--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -53,7 +53,6 @@ local function update_branch()
     -- set to '' when git dir was not found
     current_git_branch = ''
   end
-  branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
 end
 
 ---updates the current value of current_git_branch and sets up file watch on HEAD file if value changed
@@ -150,6 +149,8 @@ function M.get_branch(bufnr)
   end
   if bufnr then
     return branch_cache[bufnr] or ''
+  else
+    branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
   end
   return current_git_branch
 end


### PR DESCRIPTION
Update branch_cache on get_branch() call rather than on update_branch() call to properly cache branches for all opened buffers, instead of only the first buffer.

Fixes #1440