### PR TITLE
Updated vim.lsp.get_active_clients to vim.get_clients as per latest deprecation

### DIFF
--- a/examples/cosmicink.lua
+++ b/examples/cosmicink.lua
@@ -486,7 +486,7 @@ ins_right {
   function()
     local msg = 'No Active Lsp'
     local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
-    local clients = vim.lsp.get_active_clients()
+    local clients = vim.lsp.get_clients()
     if next(clients) == nil then
       return msg
     end

--- a/lua/lualine/components/lsp_status.lua
+++ b/lua/lualine/components/lsp_status.lua
@@ -57,7 +57,7 @@ function M:update_status()
 
   -- Backwards-compatible function to get the active LSP clients.
   ---@diagnostic disable-next-line: deprecated
-  local get_lsp_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  local get_lsp_clients = vim.lsp.get_clients
   local clients = get_lsp_clients { bufnr = vim.api.nvim_get_current_buf() }
 
   -- Backwards-compatible function to get the current time in nanoseconds.

--- a/tests/spec/component_spec.lua
+++ b/tests/spec/component_spec.lua
@@ -922,9 +922,9 @@ describe('lsp_status component', function()
   it('shows LSP name and icon in older nvim version', function()
     vim.cmd('edit ' .. file)
     vim.lsp.get_clients = nil
-    stub(vim.lsp, 'get_active_clients')
+    stub(vim.lsp, 'get_clients')
     ---@diagnostic disable-next-line: deprecated
-    vim.lsp.get_active_clients
+    vim.lsp.get_clients
       .on_call_with({ bufnr = vim.api.nvim_get_current_buf() })
       .returns { { id = 2, name = 'lua_ls' } }
 


### PR DESCRIPTION
vim.lsp.get_active_clients is deprecated and will be removed in Nvim 0.12