### PR TITLE
Update deprecated vim.lsp.get_active_clients to vim.lsp.get_clients

### DIFF
--- a/examples/cosmicink.lua
+++ b/examples/cosmicink.lua
@@ -486,7 +486,7 @@ ins_right {
   function()
     local msg = 'No Active Lsp'
     local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
-    local clients = vim.lsp.get_active_clients()
+    local clients = vim.lsp.get_clients()
     if next(clients) == nil then
       return msg
     end


### PR DESCRIPTION
I noticed that `vim.lsp.get_active_clients()` is deprecated in favour of `vim.lsp.get_clients()` which appears to provide the same functionality