### PR TITLE
fix: make bg color check case insensitive

### DIFF
--- a/lua/lualine/utils/section.lua
+++ b/lua/lualine/utils/section.lua
@@ -62,14 +62,14 @@ function M.draw_section(section, section_name, is_focused)
       (
         type(section[component_no].options.color) == 'table'
         and section[component_no].options.color.bg
-        and section[component_no].options.color.bg ~= section_color.bg
+        and string.upper(section[component_no].options.color.bg) ~= string.upper(section_color.bg)
       )
       or type(section[component_no].options.color) == 'string'
       or (
         type(section[component_no].options.color) == 'function'
         and section[component_no].color_fn_cache
         and section[component_no].color_fn_cache.bg
-        and section[component_no].color_fn_cache.bg ~= section_color.bg
+        and string.upper(section[component_no].color_fn_cache.bg) ~= string.upper(section_color.bg)
       )
     then
       strip_next_component = true


### PR DESCRIPTION
My statusline was inexplicably missing component separators when using a transparent background. The reason turned out to be that the component had `color_fn_cache.bg = "None"`, while the section had `section_color.bg = "NONE"`. This PR makes these string comparisons case insensitive to ensure that these color specs are considered equal.