### PR TITLE
git_branch: Add support for reftable format

### DIFF
--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -1,12 +1,15 @@
 local M = {}
 
-local require = require('lualine_require').require
-local utils = require('lualine.utils.utils')
+local lualine_require = require('lualine_require')
+local modules = lualine_require.lazy_require {
+  utils = 'lualine.utils.utils',
+  Job = 'lualine.utils.job',
+}
 
 -- vars
 local current_git_branch = ''
 local current_git_dir = ''
-local current_git_dir_is_reftable = false -- whether current git dir uses reftable format
+local current_git_dir_is_reftable = false
 local branch_cache = {} -- stores last known branch for a buffer
 local active_bufnr = '0'
 -- os specific path separator
@@ -16,6 +19,8 @@ local sep = package.config:sub(1, 1)
 -- Windows doesn't like file watch for some reason.
 local file_changed = sep ~= '\\' and vim.loop.new_fs_event() or vim.loop.new_fs_poll()
 local git_dir_cache = {} -- Stores git paths that we already know of
+---job handle for async git commands (reftable repos)
+local branch_job = nil
 
 ---checks if git directory uses reftable format
 ---@param git_dir string full path to .git directory
@@ -24,47 +29,6 @@ local function is_reftable_repo(git_dir)
   local reftable_dir = git_dir .. sep .. 'reftable'
   local stat = vim.loop.fs_stat(reftable_dir)
   return stat ~= nil and stat.type == 'directory'
-end
-
----runs git command asynchronously and calls callback with result
----@param git_dir string full path to .git directory
----@param args string[] git command arguments
----@param callback fun(result: string|nil) called with output or nil on error
-local function git_cmd_async(git_dir, args, callback)
-  local stdout = vim.loop.new_pipe(false)
-  local output = ''
-
-  local full_args = { '--git-dir=' .. git_dir }
-  for _, arg in ipairs(args) do
-    table.insert(full_args, arg)
-  end
-
-  local handle
-  handle = vim.loop.spawn('git', {
-    args = full_args,
-    stdio = { nil, stdout, nil },
-  }, function(code)
-    stdout:read_stop()
-    stdout:close()
-    handle:close()
-    vim.schedule(function()
-      if code == 0 and output and #output > 0 then
-        callback(vim.trim(output))
-      else
-        callback(nil)
-      end
-    end)
-  end)
-
-  if handle then
-    stdout:read_start(function(err, data)
-      if not err and data then
-        output = output .. data
-      end
-    end)
-  else
-    callback(nil)
-  end
 end
 
 ---sets git_branch variable to branch name or commit hash if not on branch
@@ -84,62 +48,97 @@ local function get_git_head(head_file)
   return nil
 end
 
+---gets short commit hash for detached HEAD in reftable repos (async)
+---@param git_dir string full path to .git directory
+---@param bufnr number buffer number to update cache for
+local function get_branch_reftable_hash(git_dir, bufnr)
+  if branch_job then
+    branch_job:stop()
+  end
+
+  local output = {}
+  branch_job = modules.Job {
+    cmd = { 'git', '--git-dir=' .. git_dir, 'rev-parse', '--short', 'HEAD' },
+    on_stdout = function(_, data)
+      if data then
+        output = vim.list_extend(output, data)
+      end
+    end,
+    on_exit = function(_, code)
+      if code == 0 and #output > 0 then
+        current_git_branch = vim.trim(table.concat(output, ''))
+      else
+        current_git_branch = ''
+      end
+      branch_cache[bufnr] = current_git_branch
+    end,
+  }
+  branch_job:start()
+end
+
 ---gets branch name for reftable repos using git command (async)
 ---@param git_dir string full path to .git directory
-local function get_branch_reftable(git_dir)
-  -- Use symbolic-ref first to get branch name, fall back to rev-parse for detached HEAD
-  git_cmd_async(git_dir, { 'symbolic-ref', '--short', 'HEAD' }, function(branch)
-    if branch then
-      current_git_branch = branch
-    else
-      -- Detached HEAD - get short commit hash
-      git_cmd_async(git_dir, { 'rev-parse', '--short', 'HEAD' }, function(hash)
-        current_git_branch = hash or ''
-        branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
-      end)
-      return
-    end
-    branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
-  end)
+---@param bufnr number buffer number to update cache for
+local function get_branch_reftable(git_dir, bufnr)
+  if branch_job then
+    branch_job:stop()
+  end
+
+  local output = {}
+  branch_job = modules.Job {
+    cmd = { 'git', '--git-dir=' .. git_dir, 'symbolic-ref', '--short', 'HEAD' },
+    on_stdout = function(_, data)
+      if data then
+        output = vim.list_extend(output, data)
+      end
+    end,
+    on_exit = function(_, code)
+      if code == 0 and #output > 0 then
+        local branch = vim.trim(table.concat(output, ''))
+        if #branch > 0 then
+          current_git_branch = branch
+          branch_cache[bufnr] = current_git_branch
+          return
+        end
+      end
+      -- Detached HEAD or error - try rev-parse for short commit hash
+      get_branch_reftable_hash(git_dir, bufnr)
+    end,
+  }
+  branch_job:start()
 end
 
 ---updates the current value of git_branch and sets up file watch on HEAD file
 local function update_branch()
-  active_bufnr = tostring(vim.api.nvim_get_current_buf())
+  local bufnr = vim.api.nvim_get_current_buf()
+  active_bufnr = tostring(bufnr)
   file_changed:stop()
   local git_dir = current_git_dir
   if git_dir and #git_dir > 0 then
+    local watch_file
     if current_git_dir_is_reftable then
       -- Reftable format: use git command to get branch name
-      get_branch_reftable(git_dir)
-      -- Watch tables.list for changes instead of HEAD
-      local tables_list = git_dir .. sep .. 'reftable' .. sep .. 'tables.list'
-      file_changed:start(
-        tables_list,
-        sep ~= '\\' and {} or 1000,
-        vim.schedule_wrap(function()
-          -- reset file-watch
-          update_branch()
-        end)
-      )
+      get_branch_reftable(git_dir, bufnr)
+      watch_file = git_dir .. sep .. 'reftable' .. sep .. 'tables.list'
     else
       -- Normal git format: read HEAD file directly
       local head_file = git_dir .. sep .. 'HEAD'
       get_git_head(head_file)
-      file_changed:start(
-        head_file,
-        sep ~= '\\' and {} or 1000,
-        vim.schedule_wrap(function()
-          -- reset file-watch
-          update_branch()
-        end)
-      )
+      watch_file = head_file
     end
+    file_changed:start(
+      watch_file,
+      sep ~= '\\' and {} or 1000,
+      vim.schedule_wrap(function()
+        -- reset file-watch
+        update_branch()
+      end)
+    )
   else
     -- set to '' when git dir was not found
     current_git_branch = ''
   end
-  branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
+  branch_cache[bufnr] = current_git_branch
 end
 
 ---updates the current value of current_git_branch and sets up file watch on HEAD file if value changed
@@ -203,12 +202,17 @@ function M.find_git_dir(dir_path)
         end
       end
       if git_dir then
+        -- Check for traditional HEAD file or reftable format
         local head_file_stat = vim.loop.fs_stat(git_dir .. sep .. 'HEAD')
         if head_file_stat and head_file_stat.type == 'file' then
           break
-        else
-          git_dir = nil
         end
+        -- Also accept reftable repos (they may not have a traditional HEAD file)
+        local reftable_stat = vim.loop.fs_stat(git_dir .. sep .. 'reftable' .. sep .. 'tables.list')
+        if reftable_stat and reftable_stat.type == 'file' then
+          break
+        end
+        git_dir = nil
       end
     end
     root_dir = root_dir:match('(.*)' .. sep .. '.-')
@@ -226,7 +230,7 @@ function M.init()
   -- run watch head on load so branch is present when component is loaded
   M.find_git_dir()
   -- update branch state of BufEnter as different Buffer may be on different repos
-  utils.define_autocmd('BufEnter', "lua require'lualine.components.branch.git_branch'.find_git_dir()")
+  modules.utils.define_autocmd('BufEnter', "lua require'lualine.components.branch.git_branch'.find_git_dir()")
 end
 function M.get_branch(bufnr)
   if vim.g.actual_curbuf ~= nil and active_bufnr ~= vim.g.actual_curbuf then

--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -6,6 +6,7 @@ local utils = require('lualine.utils.utils')
 -- vars
 local current_git_branch = ''
 local current_git_dir = ''
+local current_git_dir_is_reftable = false -- whether current git dir uses reftable format
 local branch_cache = {} -- stores last known branch for a buffer
 local active_bufnr = '0'
 -- os specific path separator
@@ -15,6 +16,56 @@ local sep = package.config:sub(1, 1)
 -- Windows doesn't like file watch for some reason.
 local file_changed = sep ~= '\\' and vim.loop.new_fs_event() or vim.loop.new_fs_poll()
 local git_dir_cache = {} -- Stores git paths that we already know of
+
+---checks if git directory uses reftable format
+---@param git_dir string full path to .git directory
+---@return boolean
+local function is_reftable_repo(git_dir)
+  local reftable_dir = git_dir .. sep .. 'reftable'
+  local stat = vim.loop.fs_stat(reftable_dir)
+  return stat ~= nil and stat.type == 'directory'
+end
+
+---runs git command asynchronously and calls callback with result
+---@param git_dir string full path to .git directory
+---@param args string[] git command arguments
+---@param callback fun(result: string|nil) called with output or nil on error
+local function git_cmd_async(git_dir, args, callback)
+  local stdout = vim.loop.new_pipe(false)
+  local output = ''
+
+  local full_args = { '--git-dir=' .. git_dir }
+  for _, arg in ipairs(args) do
+    table.insert(full_args, arg)
+  end
+
+  local handle
+  handle = vim.loop.spawn('git', {
+    args = full_args,
+    stdio = { nil, stdout, nil },
+  }, function(code)
+    stdout:read_stop()
+    stdout:close()
+    handle:close()
+    vim.schedule(function()
+      if code == 0 and output and #output > 0 then
+        callback(vim.trim(output))
+      else
+        callback(nil)
+      end
+    end)
+  end)
+
+  if handle then
+    stdout:read_start(function(err, data)
+      if not err and data then
+        output = output .. data
+      end
+    end)
+  else
+    callback(nil)
+  end
+end
 
 ---sets git_branch variable to branch name or commit hash if not on branch
 ---@param head_file string full path of .git/HEAD file
@@ -33,22 +84,57 @@ local function get_git_head(head_file)
   return nil
 end
 
+---gets branch name for reftable repos using git command (async)
+---@param git_dir string full path to .git directory
+local function get_branch_reftable(git_dir)
+  -- Use symbolic-ref first to get branch name, fall back to rev-parse for detached HEAD
+  git_cmd_async(git_dir, { 'symbolic-ref', '--short', 'HEAD' }, function(branch)
+    if branch then
+      current_git_branch = branch
+    else
+      -- Detached HEAD - get short commit hash
+      git_cmd_async(git_dir, { 'rev-parse', '--short', 'HEAD' }, function(hash)
+        current_git_branch = hash or ''
+        branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
+      end)
+      return
+    end
+    branch_cache[vim.api.nvim_get_current_buf()] = current_git_branch
+  end)
+end
+
 ---updates the current value of git_branch and sets up file watch on HEAD file
 local function update_branch()
   active_bufnr = tostring(vim.api.nvim_get_current_buf())
   file_changed:stop()
   local git_dir = current_git_dir
   if git_dir and #git_dir > 0 then
-    local head_file = git_dir .. sep .. 'HEAD'
-    get_git_head(head_file)
-    file_changed:start(
-      head_file,
-      sep ~= '\\' and {} or 1000,
-      vim.schedule_wrap(function()
-        -- reset file-watch
-        update_branch()
-      end)
-    )
+    if current_git_dir_is_reftable then
+      -- Reftable format: use git command to get branch name
+      get_branch_reftable(git_dir)
+      -- Watch tables.list for changes instead of HEAD
+      local tables_list = git_dir .. sep .. 'reftable' .. sep .. 'tables.list'
+      file_changed:start(
+        tables_list,
+        sep ~= '\\' and {} or 1000,
+        vim.schedule_wrap(function()
+          -- reset file-watch
+          update_branch()
+        end)
+      )
+    else
+      -- Normal git format: read HEAD file directly
+      local head_file = git_dir .. sep .. 'HEAD'
+      get_git_head(head_file)
+      file_changed:start(
+        head_file,
+        sep ~= '\\' and {} or 1000,
+        vim.schedule_wrap(function()
+          -- reset file-watch
+          update_branch()
+        end)
+      )
+    end
   else
     -- set to '' when git dir was not found
     current_git_branch = ''
@@ -60,6 +146,7 @@ end
 local function update_current_git_dir(git_dir)
   if current_git_dir ~= git_dir then
     current_git_dir = git_dir
+    current_git_dir_is_reftable = git_dir and is_reftable_repo(git_dir) or false
     update_branch()
   end
 end

--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -65,6 +65,7 @@ local function get_branch_reftable_hash(git_dir, bufnr)
       end
     end,
     on_exit = function(_, code)
+      if code == -1 then return end
       if code == 0 and #output > 0 then
         current_git_branch = vim.trim(table.concat(output, ''))
       else
@@ -93,6 +94,7 @@ local function get_branch_reftable(git_dir, bufnr)
       end
     end,
     on_exit = function(_, code)
+      if code == -1 then return end
       if code == 0 and #output > 0 then
         local branch = vim.trim(table.concat(output, ''))
         if #branch > 0 then

--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -66,12 +66,17 @@ local function get_branch_reftable_hash(git_dir, bufnr)
     end,
     on_exit = function(_, code)
       if code == -1 then return end
+      local branch = ''
       if code == 0 and #output > 0 then
-        current_git_branch = vim.trim(table.concat(output, ''))
-      else
-        current_git_branch = ''
+        branch = vim.trim(table.concat(output, ''))
       end
-      branch_cache[bufnr] = current_git_branch
+      if current_git_dir == git_dir then
+        current_git_branch = branch
+      end
+      branch_cache[bufnr] = branch
+      vim.schedule(function()
+        require('lualine').refresh()
+      end)
     end,
   }
   branch_job:start()
@@ -98,8 +103,13 @@ local function get_branch_reftable(git_dir, bufnr)
       if code == 0 and #output > 0 then
         local branch = vim.trim(table.concat(output, ''))
         if #branch > 0 then
-          current_git_branch = branch
-          branch_cache[bufnr] = current_git_branch
+          if current_git_dir == git_dir then
+            current_git_branch = branch
+          end
+          branch_cache[bufnr] = branch
+          vim.schedule(function()
+            require('lualine').refresh()
+          end)
           return
         end
       end
@@ -127,6 +137,7 @@ local function update_branch()
       local head_file = git_dir .. sep .. 'HEAD'
       get_git_head(head_file)
       watch_file = head_file
+      branch_cache[bufnr] = current_git_branch
     end
     file_changed:start(
       watch_file,
@@ -139,8 +150,8 @@ local function update_branch()
   else
     -- set to '' when git dir was not found
     current_git_branch = ''
+    branch_cache[bufnr] = current_git_branch
   end
-  branch_cache[bufnr] = current_git_branch
 end
 
 ---updates the current value of current_git_branch and sets up file watch on HEAD file if value changed

--- a/lua/lualine/components/branch/git_branch.lua
+++ b/lua/lualine/components/branch/git_branch.lua
@@ -65,7 +65,9 @@ local function get_branch_reftable_hash(git_dir, bufnr)
       end
     end,
     on_exit = function(_, code)
-      if code == -1 then return end
+      if code == -1 then
+        return
+      end
       local branch = ''
       if code == 0 and #output > 0 then
         branch = vim.trim(table.concat(output, ''))
@@ -99,7 +101,9 @@ local function get_branch_reftable(git_dir, bufnr)
       end
     end,
     on_exit = function(_, code)
-      if code == -1 then return end
+      if code == -1 then
+        return
+      end
       if code == 0 and #output > 0 then
         local branch = vim.trim(table.concat(output, ''))
         if #branch > 0 then

--- a/lua/lualine/utils/job.lua
+++ b/lua/lualine/utils/job.lua
@@ -6,6 +6,7 @@
 local Job = setmetatable({
   --- start the job
   start = function(self)
+    self.killed = false
     self.job_id = vim.fn.jobstart(self.args.cmd, self.args)
     return self.job_id > 0
   end,
@@ -14,11 +15,11 @@ local Job = setmetatable({
     if self.killed then
       return
     end
+    self.killed = true
     if self.job_id and self.job_id > 0 then
       vim.fn.jobstop(self.job_id)
     end
     self.job_id = 0
-    self.killed = true
   end,
   -- Wraps callbacks so they are only called when job is alive
   -- This avoids race conditions
@@ -32,6 +33,18 @@ local Job = setmetatable({
       end
     end
   end,
+  wrap_on_exit = function(self)
+    local original_cb = self.args.on_exit
+    if original_cb then
+      self.args.on_exit = function(job_id, exit_code, event_type)
+        if self.killed then
+          exit_code = -1
+        end
+        return original_cb(job_id, exit_code, event_type)
+      end
+    end
+  end
+
 }, {
   ---create new job handler
   ---@param self table base job table
@@ -47,6 +60,7 @@ local Job = setmetatable({
     job:wrap_cb_alive('on_stdout')
     job:wrap_cb_alive('on_stderr')
     job:wrap_cb_alive('on_stdin')
+    job:wrap_on_exit()
     return job
   end,
 })

--- a/lua/lualine/utils/job.lua
+++ b/lua/lualine/utils/job.lua
@@ -43,8 +43,7 @@ local Job = setmetatable({
         return original_cb(job_id, exit_code, event_type)
       end
     end
-  end
-
+  end,
 }, {
   ---create new job handler
   ---@param self table base job table


### PR DESCRIPTION
## Summary
- Add support for git repositories using the reftable format (available in Git 2.45+)
- Detect reftable repos by checking for `reftable/` directory
- Use async git commands to get branch name since reftable doesn't use traditional HEAD file
- Watch `reftable/tables.list` for branch changes instead of HEAD

Fixes https://github.com/nvim-lualine/lualine.nvim/issues/1472