### PR TITLE
fix(tabs): correctly display oil.nvim buffers in tabline

### DIFF
--- a/lua/lualine/components/tabs/tab.lua
+++ b/lua/lualine/components/tabs/tab.lua
@@ -53,6 +53,9 @@ function Tab:label()
   elseif self.buftype == 'terminal' then
     local match = string.match(vim.split(self.file, ' ')[1], 'term:.*:(%a+)')
     return match ~= nil and match or vim.fn.fnamemodify(vim.env.SHELL, ':t')
+  elseif self.filetype == 'oil' and vim.startswith(self.file, 'oil://') then
+    local path = self.file:gsub('^oil://', '')
+    return vim.fn.fnamemodify(path, ':~')
   elseif self.file == '' then
     return '[No Name]'
   end


### PR DESCRIPTION
Fixes [#1267
](https://github.com/nvim-lualine/lualine.nvim/issues/1267)

oil.nvim uses oil:// URIs as buffer names. fnamemodify() does not handle URI
schemes correctly and returns an empty string, causing tabs to show [No Name].

This patch detects oil buffers explicitly and strips the oil:// prefix before
formatting the path, keeping existing tabline behavior intact.