### PR TITLE
Make oil extension behave like default configuration

### DIFF
--- a/lua/lualine/extensions/oil.lua
+++ b/lua/lualine/extensions/oil.lua
@@ -2,17 +2,18 @@
 
 local M = {}
 
-M.sections = {
-  lualine_a = {
+local config = require('lualine.config')
+
+M.sections = vim.deepcopy(config.get_config().sections)
+M.sections.lualine_c = {
     function()
-      local ok, oil = pcall(require, 'oil')
-      if ok then
-        return vim.fn.fnamemodify(oil.get_current_dir(), ':~')
-      else
-        return ''
-      end
+        local ok, oil = pcall(require, 'oil')
+        if ok then
+            return vim.fn.fnamemodify(oil.get_current_dir(), ':~')
+        else
+            return ''
+        end
     end,
-  },
 }
 
 M.filetypes = { 'oil' }


### PR DESCRIPTION
Prior to this change, the oil extension would show an empty status line except for the file name in lualine_a.

This change make the status line behave like the default one, and sets the filename / lualine_c as the path to the shown directory.

Arguments in favor of this change:
- Keeps the status line consistent while browsing a project
- Mode is an important information inside a Oil view of a directory
- The default behavior shows the filepath as Oil:///[absolute path to file]

Caveats:
- It reads lualine.config.get_config() during extensions resolving, which is kind of a smell and may mess up other configs / make the extensions order important
  - 💭 Maybe there is a way to cleanly pass the user config to the extensions ?
- It assumes the filename is in lualine_c, which could have been changed by user.

### Oil directory status line **before** this change:
<img width="517" height="82" alt="image" src="https://github.com/user-attachments/assets/3a81c050-2495-486c-b218-9d8f7b529a1e" />

### Oil directory status line **after** this change:
<img width="659" height="65" alt="image" src="https://github.com/user-attachments/assets/a7ad01fb-5c0f-49b7-80e6-cf06024d3fde" />

📓 If this change is accepted, I'd like to make the filename configurable. I'm thinking of choosing the line to write in, and choose between relative / absolute / custom function 