### PR TITLE
feat(component): add a general spinner component

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ sections = {lualine_a = {'mode'}}
 - `tabs` (shows currently available tabs)
 - `windows` (shows currently available windows)
 - `lsp_status` (shows active LSPs in the current buffer and a progress spinner)
+- `spinner` (shows an animated spinner which can be triggered programmatically)
 
 #### Custom components
 
@@ -852,6 +853,42 @@ sections = {
 }
 ```
 
+#### spinner component options
+
+```lua
+sections = {
+    lualine_c = {
+        {
+            'spinner',
+            -- Spinner id, used as the key to start/stop independently.
+            id = 'default',
+            spinner = {
+                -- Frames used to render the spinner animation.
+                texts = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' },
+                -- Time (in milliseconds) between spinner frame updates.
+                interval = 80,
+                -- Auto-stop the spinner after this timeout (in milliseconds); 0 disable it.
+                ttl = 0,
+                -- Delay display spinner after {initial_delay} millisecond. 0 disable it
+                initial_delay = 200,
+            }
+        }
+    }
+}
+```
+
+Once the spinner component is configured, you can start or stop it
+programmatically whenever needed.
+
+```lua
+-- Use id to start/stop spinners independently.
+-- start spinner
+require('lualine').spinner.start('default')
+
+-- stop spinner
+require('lualine').spinner.stop('default')
+```
+
 ---
 
 ### Tabline
@@ -1048,6 +1085,7 @@ By default this time is set to 16ms to match 60fps. This duration can be configu
 with `options.refresh.refresh_time` option. If you want to bypass the refresh queue
 and want lualine to process the refresh immmidiately call refresh with `force=true`
 parameter set like this.
+
 ```lua
 require('lualine').refresh({
   force = true,       -- do an immidiate refresh
@@ -1055,11 +1093,11 @@ require('lualine').refresh({
   place = { 'statusline', 'winbar', 'tabline' },  -- lualine segment ro refresh.
 })
 ```
+
 Practically, speaking this is almost never needed. Also you should avoid calling
 `lualine.refresh` with `force` inside components. Since components are
 evaluated during refresh, calling refresh while refreshing can have undesirable
 effects.
-
 
 ### Disabling lualine
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -11,6 +11,7 @@ local modules = lualine_require.lazy_require {
   utils_notices = 'lualine.utils.notices',
   config_module = 'lualine.config',
   nvim_opts = 'lualine.utils.nvim_opts',
+  spinner = 'lualine.components.spinner.spinner',
 }
 local config -- Stores currently applied config
 local timers = {
@@ -706,6 +707,13 @@ M = {
   refresh = refresh,
   winbar = status_dispatch('winbar'),
   hide = hide,
+
+  spinner = {
+    ---@type fun(id: string)
+    start = modules.spinner.start,
+    ---@type fun(id: string)
+    stop = modules.spinner.stop,
+  },
 }
 
 return M

--- a/lua/lualine/components/spinner/init.lua
+++ b/lua/lualine/components/spinner/init.lua
@@ -1,0 +1,25 @@
+local lualine_require = require('lualine_require')
+
+local M = lualine_require.require('lualine.component'):extend()
+
+local modules = lualine_require.lazy_require {
+  spinner = 'lualine.components.spinner.spinner',
+}
+
+local default_options = {
+  id = 'default',
+  spinner = modules.spinner.default_options,
+}
+
+function M:init(options)
+  M.super.init(self, options)
+  self.options = vim.tbl_deep_extend('keep', self.options or {}, default_options)
+
+  self._sp = modules.spinner.new(self.options.id, self.options.spinner)
+end
+
+function M:update_status()
+  return self._sp.text
+end
+
+return M

--- a/lua/lualine/components/spinner/spinner.lua
+++ b/lua/lualine/components/spinner/spinner.lua
@@ -1,0 +1,201 @@
+local uv = vim.uv or vim.loop
+
+---@class lualine.spinner.Opts
+---@field texts? string[] spinner frames text.
+---@field initial_delay? integer millisecond
+---@field ttl? integer millisecond
+---@field interval integer
+
+---@class lualine.spinner.Spinner
+---@field id string
+---@field text string
+---@field private opts lualine.spinner.Opts
+---@field private index integer
+---@field private enabled boolean
+---@field private start_time integer
+---@field private active integer
+local Spinner = {}
+Spinner.__index = Spinner
+
+---@type lualine.spinner.Opts
+local default_options = {
+  texts = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' },
+  interval = 80,
+  ttl = 0,
+  initial_delay = 200,
+}
+
+---@class lualine.spinner.Timer
+---@field timer uv.uv_timer_t|nil
+---@field ticks table<string, fun()>
+
+---@type table<integer, lualine.spinner.Timer>
+local timers = {}
+
+---Start spinner
+---@param id string spinner id
+---@param interval integer
+---@param cb fun()
+local function start_spinner(id, interval, cb)
+  local t = timers[interval]
+  if t and t.timer then
+    t.ticks[id] = cb
+    return
+  end
+
+  t = {
+    timer = uv.new_timer(),
+    ticks = {},
+  }
+  t.ticks[id] = cb
+  timers[interval] = t
+
+  assert(t.timer, 'Failed to create spinner timer')
+  t.timer:start(
+    0,
+    interval,
+    vim.schedule_wrap(function()
+      for _, f in pairs(t.ticks) do
+        if f then
+          f()
+        end
+      end
+
+      -- combine all spinners refresh event into one.
+      require('lualine').refresh()
+    end)
+  )
+end
+
+---Stop spinner
+---@param id string spinner id
+---@param interval integer
+local function stop_spinner(id, interval)
+  local t = timers[interval]
+  if not t then
+    return
+  end
+
+  t.ticks[id] = nil
+  if next(t.ticks) == nil and t.timer then
+    t.timer:stop()
+    t.timer:close()
+    t.timer = nil
+  end
+end
+
+---Create a spinner.
+---
+---@param id string
+---@param opts? lualine.spinner.Opts
+---@return lualine.spinner.Spinner
+local function new(id, opts)
+  return setmetatable({
+    id = id,
+    text = '',
+
+    opts = vim.tbl_extend('keep', opts or {}, default_options),
+    index = 1,
+    enabled = false,
+    start_time = 0,
+    active = 0,
+  }, Spinner)
+end
+
+---Start spinner.
+function Spinner:start()
+  self.active = self.active + 1
+  -- keep refresh start_time
+  self.start_time = uv.now()
+  if self.enabled then
+    return
+  end
+
+  self.enabled = true
+
+  local do_start = function()
+    -- may stoped already
+    if not self.enabled then
+      return
+    end
+
+    -- spinner really start here.
+    self.text = self.opts.texts[self.index]
+    local length = #self.opts.texts
+
+    start_spinner(self.id, self.opts.interval, function()
+      --- spinner may have been stopped
+      if not self.enabled then
+        return
+      end
+
+      self.index = (self.index % length) + 1
+      self.text = self.opts.texts[self.index]
+      if self.opts.ttl > 0 and uv.now() - self.start_time >= self.opts.ttl then
+        self:stop()
+      end
+    end)
+  end
+
+  if self.opts.initial_delay > 0 then
+    vim.defer_fn(do_start, self.opts.initial_delay)
+  else
+    do_start()
+  end
+end
+
+---Stop spinner.
+function Spinner:stop()
+  self.active = self.active - 1
+  if not self.enabled or self.active > 0 then
+    return
+  end
+
+  stop_spinner(self.id, self.opts.interval)
+
+  self.enabled = false
+  self.active = 0
+  self.text = ''
+
+  require('lualine').refresh()
+end
+
+function Spinner:__tostring()
+  return self.text
+end
+
+local M = {}
+
+---@type table<string, lualine.spinner.Spinner>
+local instances = {}
+
+M.default_options = default_options
+
+---@param id string
+---@param opts? lualine.spinner.Opts
+---@return lualine.spinner.Spinner
+function M.new(id, opts)
+  local sp = new(id, opts)
+  instances[id] = sp
+  return sp
+end
+
+---Start spinner by id
+---@param id string
+function M.start(id)
+  local sp = instances[id]
+  if sp then
+    sp:start()
+  end
+end
+
+---Stop spinner by id
+---@param id string
+function M.stop(id)
+  local sp = instances[id]
+  if sp then
+    sp:stop()
+  end
+end
+
+return M


### PR DESCRIPTION
Add a general spinner component.

I came across the previously added component `lsp_status` ([https://github.com/nvim-lualine/lualine.nvim/pull/1376](https://github.com/nvim-lualine/lualine.nvim/pull/1376)) by @andreihh, which is a really nice!

Currently it only subscribes to `LspProgress` events. It would be beneficial if it could also display a spinner for other LSP operations, such as `lsp_diagnostic` or `lsp_goto_definition`, especially in large projects where some LSP requests can be slow. Extending `lsp_status` to cover these cases doesn’t seem very straightforward.

Moreover, spinner functionality could be useful outside of LSP contexts as well. I propose abstracting the spinner into a standalone component, providing APIs that allows other parts of the system to subscribe to arbitrary events and display a spinner accordingly. This would make the spinner more versatile and reusable across different workflows.


example:
```lua
require("lualine").setup({
    sections = {
        lualine_c = {
            { "spinner", id = "default" }
        }
    }
})

-- start spinner
require("lualine").spinner.default:start()
-- stop spinner
require("lualine").spinner.default:stop()
```

![Kapture 2026-01-28 at 12 27 28](https://github.com/user-attachments/assets/c4770b46-97d8-45ba-a518-b91900e2697a)

---
