### PR TITLE
improve base16/24 scheme integration

### DIFF
--- a/lua/lualine/themes/auto.lua
+++ b/lua/lualine/themes/auto.lua
@@ -3,18 +3,29 @@
 local utils = require('lualine.utils.utils')
 local loader = require('lualine.utils.loader')
 
-local color_name = vim.g.colors_name
-if color_name then
-  -- All base16 colorschemes share the same theme
-  if 'base16' == color_name:sub(1, 6) then
-    color_name = 'base16'
-  end
-
-  -- Check if there's a theme for current colorscheme
-  -- If there is load that instead of generating a new one
-  local ok, theme = pcall(loader.load_theme, color_name)
+local function try_load_theme(theme_name)
+  local ok, theme = pcall(loader.load_theme, theme_name)
   if ok and theme then
     return theme
+  end
+  return nil
+end
+
+local color_name = vim.g.colors_name
+if color_name then
+  -- Base16/Base24 colorschemes can be provided by either base16 or tinted themes.
+  if color_name:find('^base16%-') or color_name:find('^base24%-') then
+    local theme = try_load_theme('tinted') or try_load_theme('base16')
+    if theme then
+      return theme
+    end
+  else
+    -- Check if there's a theme for current colorscheme
+    -- If there is load that instead of generating a new one
+    local theme = try_load_theme(color_name)
+    if theme then
+      return theme
+    end
   end
 end
 

--- a/lua/lualine/themes/base16.lua
+++ b/lua/lualine/themes/base16.lua
@@ -1,9 +1,3 @@
-local modules = require('lualine_require').lazy_require { notices = 'lualine.utils.notices' }
-
-local function add_notice(notice)
-  modules.notices.add_notice('theme(base16): ' .. notice)
-end
-
 local function setup(colors)
   local theme = {
     normal = {
@@ -36,62 +30,8 @@ local function setup(colors)
   return theme
 end
 
-local function setup_default()
-  return setup {
-    bg = '#282a2e',
-    alt_bg = '#373b41',
-    dark_fg = '#969896',
-    fg = '#b4b7b4',
-    light_fg = '#c5c8c6',
-    normal = '#81a2be',
-    insert = '#b5bd68',
-    visual = '#b294bb',
-    replace = '#de935f',
-  }
-end
-
-local function setup_base16_nvim()
-  -- Continue to load nvim-base16
-  local loaded, base16 = pcall(require, 'base16-colorscheme')
-
-  if not loaded then
-    add_notice(
-      'nvim-base16 is not currently present in your runtimepath, make sure it is properly installed,'
-        .. ' fallback to default colors.'
-    )
-
-    return nil
-  end
-
-  if not base16.colors and not vim.env.BASE16_THEME then
-    add_notice(
-      'nvim-base16 is not loaded yet, you should update your configuration to load it before lualine'
-        .. ' so that the colors from your colorscheme can be used, fallback to "tomorrow-night" theme.'
-    )
-  elseif not base16.colors and not base16.colorschemes[vim.env.BASE16_THEME] then
-    add_notice(
-      'The colorscheme "%s" defined by the environment variable "BASE16_THEME" is not handled by'
-        .. ' nvim-base16, fallback to "tomorrow-night" theme.'
-    )
-  end
-
-  local colors = base16.colors or base16.colorschemes[vim.env.BASE16_THEME or 'tomorrow-night']
-
-  return setup {
-    bg = colors.base01,
-    alt_bg = colors.base02,
-    dark_fg = colors.base03,
-    fg = colors.base04,
-    light_fg = colors.base05,
-    normal = colors.base0D,
-    insert = colors.base0B,
-    visual = colors.base0E,
-    replace = colors.base09,
-  }
-end
-
-local function setup_base16_vim()
-  -- Check if tinted-theming/base16-vim is already loaded
+local function setup_from_globals()
+  -- Pull palette from base16-compatible globals.
   if vim.g.base16_gui00 and vim.g.base16_gui0F then
     return setup {
       bg = vim.g.base16_gui01,
@@ -106,8 +46,7 @@ local function setup_base16_vim()
     }
   end
 
-  -- base16-vim has been renamed to tinted-vim along with colors
-  -- context: https://github.com/nvim-lualine/lualine.nvim/pull/1352
+  -- Pull palette from tinted-vim globals.
   if vim.g.tinted_gui00 and vim.g.tinted_gui0F then
     return setup {
       bg = vim.g.tinted_gui01,
@@ -124,4 +63,4 @@ local function setup_base16_vim()
   return nil
 end
 
-return setup_base16_vim() or setup_base16_nvim() or setup_default()
+return setup_from_globals()


### PR DESCRIPTION
Hello,

I’m one of the maintainers of [tinted-theming/tinted-nvim](https://github.com/tinted-theming/tinted-nvim). We recently
completed a full rewrite of the plugin with a cleaner and more consistent API.

While reviewing Base16 integration in lualine, I noticed that [auto.lua](https://github.com/nvim-lualine/lualine.nvim/blob/47f91c416daef12db467145e16bed5bbfe00add8/lua/lualine/themes/auto.lua#L9)
matched `base16-*` names and routed them to `lualine/themes/base16.lua`. Today,
Base24 schemes are also common, so the loading logic was updated to handle
both `base16-*` and `base24-*`. 

`base16.lua` also contained multiple legacy loading
strategies, which were simplified as part of this change.

After reviewing the currently maintained Base16/Base24 implementations for Vim
and Neovim:

- [chriskempson/base16-vim](https://github.com/chriskempson/base16-vim)
- [RRethy/base16-nvim](https://github.com/RRethy/base16-nvim)
- [tinted-theming/tinted-vim](https://github.com/tinted-theming/tinted-vim)

all of them expose palette values via globals (`vim.g.*`). Because of that, the
old explicit Lua require() path is no longer necessary for these providers.

My understanding is that lualine’s preferred model is for colorscheme plugins
to ship their own lualine theme and let lualine resolve it via runtime theme
loading. That is exactly how `tinted-nvim` is designed: it provides `lua/lualine/themes/tinted.lua`, so lualine can load it directly.

With that in mind, this change simplifies `base16.lua` while preserving
compatibility:

- Keep the explicit base16 pull behavior (global variable based) for existing base16 schemes
- Remove redundant legacy loading logic
- Remove hardcoded fallback themes and return nil instead when no Base16 palette is available

Why no hardcoded fallback theme:

- hardcoded palettes can diverge from the active colorscheme and produce inconsistent UI
- lualine already has a built-in fallback flow (theme -> auto) that generates a theme from current highlights
- this keeps base16.lua focused on one responsibility: adapting Base16-style palette sources, not choosing unrelated defaults