### PR TITLE
fix: replace vim.tbl_flatten with vim.iter(...):flatten():totable()

### DIFF
--- a/lua/lualine/utils/notices.lua
+++ b/lua/lualine/utils/notices.lua
@@ -74,8 +74,16 @@ function M.show_notices()
     vim.cmd('normal q')
     return
   end
-  local notice = vim.tbl_flatten(persistent_notices)
-  notice = vim.list_extend(notice, vim.tbl_flatten(notices))
+
+  local flatten
+  if vim.version.ge(vim.version(), {0, 10, 0}) then
+    flatten = function(t) return vim.iter(t):flatten():totable() end
+  else
+    flatten = vim.tbl_flatten
+  end
+
+  local notice = flatten(persistent_notices)
+  notice = vim.list_extend(notice, flatten(notices))
   vim.fn.appendbufline(bufnr, 0, notice)
 
   vim.fn.deletebufline(bufnr, #notice, vim.fn.line('$'))


### PR DESCRIPTION
## Environemnt
- neovim v0.12.0
- macOS Tahoe 26.4

## Problem
- I provided an invalid theme name in my init.vim within `require("lualine").setup()`, and it told me to run `:LualineNotices`.
- Running `:LualineNotices` would show another warning, something like "vim.tbl_flatten is deprecated, run :checkhealth vim.deprecated for more info"
- Finally, running `:checkhealth vim.deprecated` shows the following warning:
```
- ⚠️ WARNING vim.tbl_flatten is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use vim.iter(…):flatten():totable() instead.
    - stack traceback:
        /Users/aesophor/.local/share/nvim/plugged/lualine.nvim/lua/lualine/utils/notices.lua:77
        :lua:1
    - stack traceback:
        /Users/aesophor/.local/share/nvim/plugged/lualine.nvim/lua/lualine/utils/notices.lua:78
        :lua:1
```

## Solution
Replace vim.tbl_flatten() with vim.iter(...):flatten():totable().

## Results
<img width="716" height="334" alt="Screenshot 2026-04-03 at 4 26 45 PM" src="https://github.com/user-attachments/assets/9bd6798a-f974-428e-a214-440daff12042" />