### PR TITLE
fix: extension with shared section subtables crashes setup (#1507)

### DIFF
--- a/lua/lualine/utils/loader.lua
+++ b/lua/lualine/utils/loader.lua
@@ -183,6 +183,8 @@ Extension named `%s` was not found . Check if spelling is correct.
       local local_extension = modules.utils.deepcopy(extension)
       for _, section in ipairs(sec_names) do
         if local_extension[section] then
+          -- break shared refs across sections (e.g. inactive_winbar = winbar) so load_sections doesn't mutate twice (#1507)
+          local_extension[section] = modules.utils.deepcopy(local_extension[section])
           load_sections(local_extension[section], config.options)
         end
       end

--- a/tests/spec/lualine_spec.lua
+++ b/tests/spec/lualine_spec.lua
@@ -358,6 +358,25 @@ describe('Lualine', function()
     vim.bo.ft = old_ft
   end)
 
+  it('extensions with shared section subtables load without error', function()
+    local ext = {
+      filetypes = { 'test_ft_shared' },
+      winbar = {
+        lualine_a = {
+          function()
+            return 'shared_extension_component'
+          end,
+        },
+      },
+    }
+    ext.inactive_winbar = ext.winbar
+    table.insert(config.extensions, ext)
+    local old_ft = vim.bo.ft
+    vim.bo.ft = 'test_ft_shared'
+    require('lualine').setup(config)
+    vim.bo.ft = old_ft
+  end)
+
   -- TODO: figure put why some of the tablines tests fail in CI
   describe('tabline', function()
     local tab_conf = vim.deepcopy(config)


### PR DESCRIPTION
Fixes #1507.

`load_extensions` deepcopies the extension table before processing it, but the deepcopy is cycle-aware and preserves shared subtable identity. So if the user aliases two section keys (e.g. `ext.inactive_winbar = ext.winbar`), the copy still has both keys pointing at the same subtable. `load_sections` then mutates `section[index]` in place on the first pass; on the second pass the already-loaded component instance gets re-wrapped and run through `component_loader` again, which crashes in `class.lua` with `attempt to call method 'init' (a nil value)`.

Fix: deepcopy each section table itself before passing it to `load_sections`, breaking the shared reference. The outer deepcopy still runs once (needed for top-level fields like `init`), so this is one extra copy per section.

Repro from the issue passes after the patch:

```lua
local help_ext = {
    filetypes = { 'help' },
    winbar = {
        lualine_a = { 'filename' },
        lualine_z = { 'searchcount', 'progress' },
    },
}
help_ext.inactive_winbar = help_ext.winbar
require('lualine').setup({ extensions = { help_ext } })
```

Added a regression test in `tests/spec/lualine_spec.lua`. Ran the suite locally — the new test passes and existing pass/fail counts are unchanged (the 8 pre-existing failures are Windows path-separator tests, unrelated).